### PR TITLE
develop: 도커 이미지 빌드시 .env 포함되도록 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM openjdk:17-jdk-slim
 WORKDIR /app
 
 COPY build/libs/weat-0.0.1-SNAPSHOT.jar app.jar
+COPY .env .env
 
 EXPOSE 8080
 


### PR DESCRIPTION
## 🔧 작업 내용
- 도커 이미지 빌드 시 .env가 jar와 동일한 위치에 포함되도록 수정하였습니다. 