### PR TITLE
refactor/global - 공통 클래스 패키지 통일 및 공통 응답 클래스에서 postfix(DTO) 제거

### DIFF
--- a/src/main/java/com/waguwagu/weat/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/waguwagu/weat/domain/admin/controller/AdminController.java
@@ -2,7 +2,7 @@ package com.waguwagu.weat.domain.admin.controller;
 
 import com.waguwagu.weat.domain.admin.dto.*;
 import com.waguwagu.weat.domain.admin.service.AdminService;
-import com.waguwagu.weat.domain.common.dto.ResponseDTO;
+import com.waguwagu.weat.global.model.ResponseDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;

--- a/src/main/java/com/waguwagu/weat/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/waguwagu/weat/domain/admin/controller/AdminController.java
@@ -2,7 +2,7 @@ package com.waguwagu.weat.domain.admin.controller;
 
 import com.waguwagu.weat.domain.admin.dto.*;
 import com.waguwagu.weat.domain.admin.service.AdminService;
-import com.waguwagu.weat.global.model.ResponseDTO;
+import com.waguwagu.weat.global.model.Response;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -75,21 +75,21 @@ public class AdminController {
     }
 
     @PutMapping("/categoryTags")
-    public ResponseDTO<RenameCategoryTagDTO.Response> renameCategoryTag(
+    public Response<RenameCategoryTagDTO.Response> renameCategoryTag(
             @RequestBody RenameCategoryTagDTO.Request request) {
-        return ResponseDTO.of(adminService.renameCategoryTag(request));
+        return Response.of(adminService.renameCategoryTag(request));
     }
 
     @DeleteMapping("/categoryTags/{categoryTagId}")
-    public ResponseDTO<DeleteCategoryTagDTO.Response> deleteCategoryTag
+    public Response<DeleteCategoryTagDTO.Response> deleteCategoryTag
             (@PathVariable("categoryTagId") Long categoryTagId) {
-        return ResponseDTO.of(adminService.deleteCategoryTag(categoryTagId));
+        return Response.of(adminService.deleteCategoryTag(categoryTagId));
     }
 
     @PostMapping("/categories/{categoryId}/categoryTags")
-    public ResponseDTO<CreateCategoryTagDTO.Response> createCategoryTag(
+    public Response<CreateCategoryTagDTO.Response> createCategoryTag(
             @PathVariable("categoryId") Long categoryId,
             @RequestBody CreateCategoryTagDTO.Request request) {
-        return ResponseDTO.of(adminService.createCategoryTag(categoryId, request));
+        return Response.of(adminService.createCategoryTag(categoryId, request));
     }
 }

--- a/src/main/java/com/waguwagu/weat/domain/analysis/adaptor/AIServiceAdaptor.java
+++ b/src/main/java/com/waguwagu/weat/domain/analysis/adaptor/AIServiceAdaptor.java
@@ -4,13 +4,12 @@ import com.waguwagu.weat.domain.analysis.exception.AIServerException;
 import com.waguwagu.weat.domain.analysis.model.dto.AIAnalysisDTO;
 
 import com.waguwagu.weat.domain.analysis.model.dto.ValidationDTO;
-import com.waguwagu.weat.domain.common.dto.AIErrorResponse;
+import com.waguwagu.weat.global.model.AIErrorResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
 import org.springframework.stereotype.Component;
-import org.springframework.web.client.RestTemplate;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 

--- a/src/main/java/com/waguwagu/weat/domain/analysis/controller/AnalysisController.java
+++ b/src/main/java/com/waguwagu/weat/domain/analysis/controller/AnalysisController.java
@@ -2,7 +2,7 @@ package com.waguwagu.weat.domain.analysis.controller;
 
 import com.waguwagu.weat.domain.analysis.model.dto.*;
 import com.waguwagu.weat.domain.analysis.service.AnalysisService;
-import com.waguwagu.weat.global.model.ResponseDTO;
+import com.waguwagu.weat.global.model.Response;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
@@ -69,9 +69,9 @@ public class AnalysisController {
             )
     )
     @PostMapping("/settings")
-    public ResponseDTO<SubmitAnalysisSettingDTO.Response> submitAnalysisSetting(
+    public Response<SubmitAnalysisSettingDTO.Response> submitAnalysisSetting(
             @RequestBody SubmitAnalysisSettingDTO.Request requestDto) {
-        return ResponseDTO.of(analysisService.submitAnalysisSetting(requestDto));
+        return Response.of(analysisService.submitAnalysisSetting(requestDto));
     }
 
 
@@ -105,8 +105,8 @@ public class AnalysisController {
             )
     )
     @GetMapping(value = "/settings/status")
-    public ResponseDTO<IsMemberSubmitAnalysisSettingDTO.Response> isMemberSubmitAnalysisSetting(@RequestParam("memberId") Long memberId) {
-        return ResponseDTO.of(analysisService.isMemberSubmitAnalysisSetting(memberId));
+    public Response<IsMemberSubmitAnalysisSettingDTO.Response> isMemberSubmitAnalysisSetting(@RequestParam("memberId") Long memberId) {
+        return Response.of(analysisService.isMemberSubmitAnalysisSetting(memberId));
     }
 
     @Operation(summary = "분석 상태 조회", description =
@@ -143,8 +143,8 @@ public class AnalysisController {
             )
     )
     @GetMapping("/status")
-    public ResponseDTO<GetAnalysisStatusDTO.Response> getAnalysisStatus(@RequestParam("groupId") String groupId) {
-        return ResponseDTO.of(analysisService.getAnalysisStatus(groupId));
+    public Response<GetAnalysisStatusDTO.Response> getAnalysisStatus(@RequestParam("groupId") String groupId) {
+        return Response.of(analysisService.getAnalysisStatus(groupId));
     }
 
     // TODO: 개발 진행중, AI 분석 서비스 응답 형식 정해지면 재개
@@ -215,8 +215,8 @@ public class AnalysisController {
             )
     )
     @PostMapping
-    public ResponseDTO<AnalysisStartDTO.Response> analysisStart(@RequestBody AnalysisStartDTO.Request request) {
-        return ResponseDTO.of(analysisService.analysisStart(request));
+    public Response<AnalysisStartDTO.Response> analysisStart(@RequestBody AnalysisStartDTO.Request request) {
+        return Response.of(analysisService.analysisStart(request));
     }
 
 
@@ -250,9 +250,9 @@ public class AnalysisController {
             )
     )
     @PostMapping("/validation/input")
-    public Mono<ResponseDTO<ValidationDTO.Response>> validateInput(@RequestBody ValidationDTO.Request request) {
+    public Mono<Response<ValidationDTO.Response>> validateInput(@RequestBody ValidationDTO.Request request) {
         return analysisService.validateInput(request)
-                .map(ResponseDTO::of);
+                .map(Response::of);
     }
 
     @Operation(summary = "분석결과상세(장소)별 좋아요 토글", description = "분석결과의 각 장소에 대해 좋아요를 활성화 또는 비활성화한다.")
@@ -265,8 +265,8 @@ public class AnalysisController {
             )
     )
     @PostMapping("/likes")
-    public ResponseDTO<ToggleAnalysisResultDetailLikeDTO.Response> toggleAnalysisDetail(@RequestBody ToggleAnalysisResultDetailLikeDTO.Request request) {
-        return ResponseDTO.of(analysisService.toggleAnalysisResultDetailLike(request));
+    public Response<ToggleAnalysisResultDetailLikeDTO.Response> toggleAnalysisDetail(@RequestBody ToggleAnalysisResultDetailLikeDTO.Request request) {
+        return Response.of(analysisService.toggleAnalysisResultDetailLike(request));
     }
 
     @Operation(summary = "분석결과상세(장소)별 좋아요 개수 조회", description = "분석결과의 각 장소에 대한 좋아요 개수를 조회한다.")
@@ -279,8 +279,8 @@ public class AnalysisController {
             )
     )
     @GetMapping("/likes")
-    public ResponseDTO<GetAnalysisResultLikeCountDTO.Response> getAnalysisDetailLikeCount(@RequestParam("analysisDetailId") Long analysisDetailId) {
-        return ResponseDTO.of(analysisService.getAnalysisResultLikeCount(analysisDetailId));
+    public Response<GetAnalysisResultLikeCountDTO.Response> getAnalysisDetailLikeCount(@RequestParam("analysisDetailId") Long analysisDetailId) {
+        return Response.of(analysisService.getAnalysisResultLikeCount(analysisDetailId));
     }
 
 
@@ -297,10 +297,10 @@ public class AnalysisController {
             )
     )
     @GetMapping("/likes/status")
-    public ResponseDTO<GetAnalysisResultLikeStatusByDetailDTO.Response> getAnalysisResultLikeStatusByDetail(
+    public Response<GetAnalysisResultLikeStatusByDetailDTO.Response> getAnalysisResultLikeStatusByDetail(
             @RequestParam("analysisResultDetailId") Long analysisDetailId,
             @RequestParam("memberId") Long memberId) {
-        return ResponseDTO.of(analysisService.getAnalysisResultLikeStatusByDetail(analysisDetailId, memberId));
+        return Response.of(analysisService.getAnalysisResultLikeStatusByDetail(analysisDetailId, memberId));
     }
 
 

--- a/src/main/java/com/waguwagu/weat/domain/analysis/controller/AnalysisController.java
+++ b/src/main/java/com/waguwagu/weat/domain/analysis/controller/AnalysisController.java
@@ -1,9 +1,8 @@
 package com.waguwagu.weat.domain.analysis.controller;
 
-import com.waguwagu.weat.domain.analysis.adaptor.AIServiceAdaptor;
 import com.waguwagu.weat.domain.analysis.model.dto.*;
 import com.waguwagu.weat.domain.analysis.service.AnalysisService;
-import com.waguwagu.weat.domain.common.dto.ResponseDTO;
+import com.waguwagu.weat.global.model.ResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;

--- a/src/main/java/com/waguwagu/weat/domain/analysis/model/dto/AnalysisStartDTOResponseWrapper.java
+++ b/src/main/java/com/waguwagu/weat/domain/analysis/model/dto/AnalysisStartDTOResponseWrapper.java
@@ -1,6 +1,6 @@
 package com.waguwagu.weat.domain.analysis.model.dto;
 
-import com.waguwagu.weat.global.model.ResponseDTO;
+import com.waguwagu.weat.global.model.Response;
 
-public class AnalysisStartDTOResponseWrapper extends ResponseDTO<AnalysisStartDTO.Response> {
+public class AnalysisStartDTOResponseWrapper extends Response<AnalysisStartDTO.Response> {
 }

--- a/src/main/java/com/waguwagu/weat/domain/analysis/model/dto/AnalysisStartDTOResponseWrapper.java
+++ b/src/main/java/com/waguwagu/weat/domain/analysis/model/dto/AnalysisStartDTOResponseWrapper.java
@@ -1,6 +1,6 @@
 package com.waguwagu.weat.domain.analysis.model.dto;
 
-import com.waguwagu.weat.domain.common.dto.ResponseDTO;
+import com.waguwagu.weat.global.model.ResponseDTO;
 
 public class AnalysisStartDTOResponseWrapper extends ResponseDTO<AnalysisStartDTO.Response> {
 }

--- a/src/main/java/com/waguwagu/weat/domain/analysis/model/dto/GetAnalysisResultLikeCountResponseWrapper.java
+++ b/src/main/java/com/waguwagu/weat/domain/analysis/model/dto/GetAnalysisResultLikeCountResponseWrapper.java
@@ -1,6 +1,6 @@
 package com.waguwagu.weat.domain.analysis.model.dto;
 
-import com.waguwagu.weat.global.model.ResponseDTO;
+import com.waguwagu.weat.global.model.Response;
 
-public class GetAnalysisResultLikeCountResponseWrapper extends ResponseDTO<GetAnalysisResultLikeCountDTO.Response> {
+public class GetAnalysisResultLikeCountResponseWrapper extends Response<GetAnalysisResultLikeCountDTO.Response> {
 }

--- a/src/main/java/com/waguwagu/weat/domain/analysis/model/dto/GetAnalysisResultLikeCountResponseWrapper.java
+++ b/src/main/java/com/waguwagu/weat/domain/analysis/model/dto/GetAnalysisResultLikeCountResponseWrapper.java
@@ -1,6 +1,6 @@
 package com.waguwagu.weat.domain.analysis.model.dto;
 
-import com.waguwagu.weat.domain.common.dto.ResponseDTO;
+import com.waguwagu.weat.global.model.ResponseDTO;
 
 public class GetAnalysisResultLikeCountResponseWrapper extends ResponseDTO<GetAnalysisResultLikeCountDTO.Response> {
 }

--- a/src/main/java/com/waguwagu/weat/domain/analysis/model/dto/GetAnalysisResultLikeStatusByDetailResponseWrapper.java
+++ b/src/main/java/com/waguwagu/weat/domain/analysis/model/dto/GetAnalysisResultLikeStatusByDetailResponseWrapper.java
@@ -1,6 +1,6 @@
 package com.waguwagu.weat.domain.analysis.model.dto;
 
-import com.waguwagu.weat.global.model.ResponseDTO;
+import com.waguwagu.weat.global.model.Response;
 
-public class GetAnalysisResultLikeStatusByDetailResponseWrapper extends ResponseDTO<GetAnalysisResultLikeStatusByDetailDTO.Response> {
+public class GetAnalysisResultLikeStatusByDetailResponseWrapper extends Response<GetAnalysisResultLikeStatusByDetailDTO.Response> {
 }

--- a/src/main/java/com/waguwagu/weat/domain/analysis/model/dto/GetAnalysisResultLikeStatusByDetailResponseWrapper.java
+++ b/src/main/java/com/waguwagu/weat/domain/analysis/model/dto/GetAnalysisResultLikeStatusByDetailResponseWrapper.java
@@ -1,6 +1,6 @@
 package com.waguwagu.weat.domain.analysis.model.dto;
 
-import com.waguwagu.weat.domain.common.dto.ResponseDTO;
+import com.waguwagu.weat.global.model.ResponseDTO;
 
 public class GetAnalysisResultLikeStatusByDetailResponseWrapper extends ResponseDTO<GetAnalysisResultLikeStatusByDetailDTO.Response> {
 }

--- a/src/main/java/com/waguwagu/weat/domain/analysis/model/dto/IsAnalysisStartAvailableDtoResponseWrapper.java
+++ b/src/main/java/com/waguwagu/weat/domain/analysis/model/dto/IsAnalysisStartAvailableDtoResponseWrapper.java
@@ -1,7 +1,7 @@
 package com.waguwagu.weat.domain.analysis.model.dto;
 
-import com.waguwagu.weat.global.model.ResponseDTO;
+import com.waguwagu.weat.global.model.Response;
 
 
-public class IsAnalysisStartAvailableDtoResponseWrapper extends ResponseDTO<GetAnalysisStatusDTO.Response> {
+public class IsAnalysisStartAvailableDtoResponseWrapper extends Response<GetAnalysisStatusDTO.Response> {
 }

--- a/src/main/java/com/waguwagu/weat/domain/analysis/model/dto/IsAnalysisStartAvailableDtoResponseWrapper.java
+++ b/src/main/java/com/waguwagu/weat/domain/analysis/model/dto/IsAnalysisStartAvailableDtoResponseWrapper.java
@@ -1,6 +1,6 @@
 package com.waguwagu.weat.domain.analysis.model.dto;
 
-import com.waguwagu.weat.domain.common.dto.ResponseDTO;
+import com.waguwagu.weat.global.model.ResponseDTO;
 
 
 public class IsAnalysisStartAvailableDtoResponseWrapper extends ResponseDTO<GetAnalysisStatusDTO.Response> {

--- a/src/main/java/com/waguwagu/weat/domain/analysis/model/dto/IsMemberSubmitAnalysisSettingDtoResponseWrapper.java
+++ b/src/main/java/com/waguwagu/weat/domain/analysis/model/dto/IsMemberSubmitAnalysisSettingDtoResponseWrapper.java
@@ -1,8 +1,8 @@
 package com.waguwagu.weat.domain.analysis.model.dto;
 
-import com.waguwagu.weat.global.model.ResponseDTO;
+import com.waguwagu.weat.global.model.Response;
 import lombok.Getter;
 
 @Getter
-public class IsMemberSubmitAnalysisSettingDtoResponseWrapper extends ResponseDTO<IsMemberSubmitAnalysisSettingDTO.Response> {
+public class IsMemberSubmitAnalysisSettingDtoResponseWrapper extends Response<IsMemberSubmitAnalysisSettingDTO.Response> {
 }

--- a/src/main/java/com/waguwagu/weat/domain/analysis/model/dto/IsMemberSubmitAnalysisSettingDtoResponseWrapper.java
+++ b/src/main/java/com/waguwagu/weat/domain/analysis/model/dto/IsMemberSubmitAnalysisSettingDtoResponseWrapper.java
@@ -1,8 +1,7 @@
 package com.waguwagu.weat.domain.analysis.model.dto;
 
-import com.waguwagu.weat.domain.common.dto.ResponseDTO;
+import com.waguwagu.weat.global.model.ResponseDTO;
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
 public class IsMemberSubmitAnalysisSettingDtoResponseWrapper extends ResponseDTO<IsMemberSubmitAnalysisSettingDTO.Response> {

--- a/src/main/java/com/waguwagu/weat/domain/analysis/model/dto/SubmitAnalysisSettingDtoResponseWrapper.java
+++ b/src/main/java/com/waguwagu/weat/domain/analysis/model/dto/SubmitAnalysisSettingDtoResponseWrapper.java
@@ -1,8 +1,6 @@
 package com.waguwagu.weat.domain.analysis.model.dto;
 
-import com.waguwagu.weat.domain.common.dto.ResponseDTO;
-import lombok.Getter;
-import lombok.Setter;
+import com.waguwagu.weat.global.model.ResponseDTO;
 
 
 public class SubmitAnalysisSettingDtoResponseWrapper extends ResponseDTO<SubmitAnalysisSettingDTO.Response> {

--- a/src/main/java/com/waguwagu/weat/domain/analysis/model/dto/SubmitAnalysisSettingDtoResponseWrapper.java
+++ b/src/main/java/com/waguwagu/weat/domain/analysis/model/dto/SubmitAnalysisSettingDtoResponseWrapper.java
@@ -1,7 +1,7 @@
 package com.waguwagu.weat.domain.analysis.model.dto;
 
-import com.waguwagu.weat.global.model.ResponseDTO;
+import com.waguwagu.weat.global.model.Response;
 
 
-public class SubmitAnalysisSettingDtoResponseWrapper extends ResponseDTO<SubmitAnalysisSettingDTO.Response> {
+public class SubmitAnalysisSettingDtoResponseWrapper extends Response<SubmitAnalysisSettingDTO.Response> {
 }

--- a/src/main/java/com/waguwagu/weat/domain/analysis/model/dto/ToggleAnalysisResultDetailLikeResponseWrapper.java
+++ b/src/main/java/com/waguwagu/weat/domain/analysis/model/dto/ToggleAnalysisResultDetailLikeResponseWrapper.java
@@ -1,6 +1,6 @@
 package com.waguwagu.weat.domain.analysis.model.dto;
 
-import com.waguwagu.weat.domain.common.dto.ResponseDTO;
+import com.waguwagu.weat.global.model.ResponseDTO;
 
 public class ToggleAnalysisResultDetailLikeResponseWrapper extends ResponseDTO<ToggleAnalysisResultDetailLikeDTO.Response> {
 }

--- a/src/main/java/com/waguwagu/weat/domain/analysis/model/dto/ToggleAnalysisResultDetailLikeResponseWrapper.java
+++ b/src/main/java/com/waguwagu/weat/domain/analysis/model/dto/ToggleAnalysisResultDetailLikeResponseWrapper.java
@@ -1,6 +1,6 @@
 package com.waguwagu.weat.domain.analysis.model.dto;
 
-import com.waguwagu.weat.global.model.ResponseDTO;
+import com.waguwagu.weat.global.model.Response;
 
-public class ToggleAnalysisResultDetailLikeResponseWrapper extends ResponseDTO<ToggleAnalysisResultDetailLikeDTO.Response> {
+public class ToggleAnalysisResultDetailLikeResponseWrapper extends Response<ToggleAnalysisResultDetailLikeDTO.Response> {
 }

--- a/src/main/java/com/waguwagu/weat/domain/analysis/model/dto/ValidationDTOResponseWrapper.java
+++ b/src/main/java/com/waguwagu/weat/domain/analysis/model/dto/ValidationDTOResponseWrapper.java
@@ -1,6 +1,6 @@
 package com.waguwagu.weat.domain.analysis.model.dto;
 
-import com.waguwagu.weat.global.model.ResponseDTO;
+import com.waguwagu.weat.global.model.Response;
 
-public class ValidationDTOResponseWrapper extends ResponseDTO<ValidationDTO.Response> {
+public class ValidationDTOResponseWrapper extends Response<ValidationDTO.Response> {
 }

--- a/src/main/java/com/waguwagu/weat/domain/analysis/model/dto/ValidationDTOResponseWrapper.java
+++ b/src/main/java/com/waguwagu/weat/domain/analysis/model/dto/ValidationDTOResponseWrapper.java
@@ -1,6 +1,6 @@
 package com.waguwagu.weat.domain.analysis.model.dto;
 
-import com.waguwagu.weat.domain.common.dto.ResponseDTO;
+import com.waguwagu.weat.global.model.ResponseDTO;
 
 public class ValidationDTOResponseWrapper extends ResponseDTO<ValidationDTO.Response> {
 }

--- a/src/main/java/com/waguwagu/weat/domain/group/controller/GroupController.java
+++ b/src/main/java/com/waguwagu/weat/domain/group/controller/GroupController.java
@@ -1,6 +1,6 @@
 package com.waguwagu.weat.domain.group.controller;
 
-import com.waguwagu.weat.global.model.ResponseDTO;
+import com.waguwagu.weat.global.model.Response;
 import com.waguwagu.weat.domain.group.model.dto.*;
 import com.waguwagu.weat.domain.group.service.GroupService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -30,8 +30,8 @@ public class GroupController {
             )
     )
     @PostMapping
-    public ResponseDTO<CreateGroupDTO.Response> createGroup(@RequestBody CreateGroupDTO.Request request) {
-        return ResponseDTO.of(groupService.createGroup(request));
+    public Response<CreateGroupDTO.Response> createGroup(@RequestBody CreateGroupDTO.Request request) {
+        return Response.of(groupService.createGroup(request));
     }
 
     @Operation(summary = "그룹 참여", description = "생성된 그룹에 참여합니다.")
@@ -64,8 +64,8 @@ public class GroupController {
             )
     )
     @PostMapping("/{groupId}/members")
-    public ResponseDTO<JoinGroupDTO.Response> joinGroup(@PathVariable("groupId") String groupId) {
-        return ResponseDTO.of(groupService.joinGroup(groupId));
+    public Response<JoinGroupDTO.Response> joinGroup(@PathVariable("groupId") String groupId) {
+        return Response.of(groupService.joinGroup(groupId));
     }
 
 
@@ -99,7 +99,7 @@ public class GroupController {
             )
     )
     @PostMapping("/{groupId}/result")
-    public ResponseDTO<GroupResultDTO.Response> getGroupResult(@PathVariable("groupId") String groupId) {
-        return ResponseDTO.of(groupService.getGroupResult(groupId));
+    public Response<GroupResultDTO.Response> getGroupResult(@PathVariable("groupId") String groupId) {
+        return Response.of(groupService.getGroupResult(groupId));
     }
 }

--- a/src/main/java/com/waguwagu/weat/domain/group/controller/GroupController.java
+++ b/src/main/java/com/waguwagu/weat/domain/group/controller/GroupController.java
@@ -1,6 +1,6 @@
 package com.waguwagu.weat.domain.group.controller;
 
-import com.waguwagu.weat.domain.common.dto.ResponseDTO;
+import com.waguwagu.weat.global.model.ResponseDTO;
 import com.waguwagu.weat.domain.group.model.dto.*;
 import com.waguwagu.weat.domain.group.service.GroupService;
 import io.swagger.v3.oas.annotations.Operation;

--- a/src/main/java/com/waguwagu/weat/domain/group/model/dto/CreateGroupDtoResponseWrapper.java
+++ b/src/main/java/com/waguwagu/weat/domain/group/model/dto/CreateGroupDtoResponseWrapper.java
@@ -1,7 +1,7 @@
 package com.waguwagu.weat.domain.group.model.dto;
 
-import com.waguwagu.weat.global.model.ResponseDTO;
+import com.waguwagu.weat.global.model.Response;
 
 
-public class CreateGroupDtoResponseWrapper extends ResponseDTO<CreateGroupDTO.Response> {
+public class CreateGroupDtoResponseWrapper extends Response<CreateGroupDTO.Response> {
 }

--- a/src/main/java/com/waguwagu/weat/domain/group/model/dto/CreateGroupDtoResponseWrapper.java
+++ b/src/main/java/com/waguwagu/weat/domain/group/model/dto/CreateGroupDtoResponseWrapper.java
@@ -1,6 +1,6 @@
 package com.waguwagu.weat.domain.group.model.dto;
 
-import com.waguwagu.weat.domain.common.dto.ResponseDTO;
+import com.waguwagu.weat.global.model.ResponseDTO;
 
 
 public class CreateGroupDtoResponseWrapper extends ResponseDTO<CreateGroupDTO.Response> {

--- a/src/main/java/com/waguwagu/weat/domain/group/model/dto/GroupResultDtoResponseWrapper.java
+++ b/src/main/java/com/waguwagu/weat/domain/group/model/dto/GroupResultDtoResponseWrapper.java
@@ -1,7 +1,7 @@
 package com.waguwagu.weat.domain.group.model.dto;
 
-import com.waguwagu.weat.global.model.ResponseDTO;
+import com.waguwagu.weat.global.model.Response;
 
 
-public class GroupResultDtoResponseWrapper extends ResponseDTO<GroupResultDTO.Response> {
+public class GroupResultDtoResponseWrapper extends Response<GroupResultDTO.Response> {
 }

--- a/src/main/java/com/waguwagu/weat/domain/group/model/dto/GroupResultDtoResponseWrapper.java
+++ b/src/main/java/com/waguwagu/weat/domain/group/model/dto/GroupResultDtoResponseWrapper.java
@@ -1,6 +1,6 @@
 package com.waguwagu.weat.domain.group.model.dto;
 
-import com.waguwagu.weat.domain.common.dto.ResponseDTO;
+import com.waguwagu.weat.global.model.ResponseDTO;
 
 
 public class GroupResultDtoResponseWrapper extends ResponseDTO<GroupResultDTO.Response> {

--- a/src/main/java/com/waguwagu/weat/domain/group/model/dto/JoinGroupDtoResponseWrapper.java
+++ b/src/main/java/com/waguwagu/weat/domain/group/model/dto/JoinGroupDtoResponseWrapper.java
@@ -1,7 +1,7 @@
 package com.waguwagu.weat.domain.group.model.dto;
 
-import com.waguwagu.weat.global.model.ResponseDTO;
+import com.waguwagu.weat.global.model.Response;
 
 
-public class JoinGroupDtoResponseWrapper extends ResponseDTO<JoinGroupDTO.Response> {
+public class JoinGroupDtoResponseWrapper extends Response<JoinGroupDTO.Response> {
 }

--- a/src/main/java/com/waguwagu/weat/domain/group/model/dto/JoinGroupDtoResponseWrapper.java
+++ b/src/main/java/com/waguwagu/weat/domain/group/model/dto/JoinGroupDtoResponseWrapper.java
@@ -1,6 +1,6 @@
 package com.waguwagu.weat.domain.group.model.dto;
 
-import com.waguwagu.weat.domain.common.dto.ResponseDTO;
+import com.waguwagu.weat.global.model.ResponseDTO;
 
 
 public class JoinGroupDtoResponseWrapper extends ResponseDTO<JoinGroupDTO.Response> {

--- a/src/main/java/com/waguwagu/weat/domain/group/service/GroupService.java
+++ b/src/main/java/com/waguwagu/weat/domain/group/service/GroupService.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.waguwagu.weat.domain.analysis.model.entity.Analysis;
 import com.waguwagu.weat.domain.analysis.model.entity.AnalysisStatus;
 import com.waguwagu.weat.domain.analysis.repository.AnalysisRepository;
-import com.waguwagu.weat.domain.common.utils.JsonbUtils;
+import com.waguwagu.weat.global.utils.JsonbUtils;
 import com.waguwagu.weat.domain.group.exception.GroupMemberLimitExceededException;
 import com.waguwagu.weat.domain.group.exception.GroupNotFoundException;
 import com.waguwagu.weat.domain.group.mapper.GroupMapper;
@@ -18,7 +18,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/waguwagu/weat/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/waguwagu/weat/global/exception/GlobalExceptionHandler.java
@@ -1,7 +1,6 @@
 package com.waguwagu.weat.global.exception;
 
-import com.waguwagu.weat.domain.common.dto.ResponseDTO;
-import org.springframework.http.HttpStatus;
+import com.waguwagu.weat.global.model.ResponseDTO;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;

--- a/src/main/java/com/waguwagu/weat/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/waguwagu/weat/global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,6 @@
 package com.waguwagu.weat.global.exception;
 
-import com.waguwagu.weat.global.model.ResponseDTO;
+import com.waguwagu.weat.global.model.Response;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -9,9 +9,9 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(BaseException.class)
-    public ResponseEntity<ResponseDTO<?>> handleBaseException(BaseException e) {
+    public ResponseEntity<Response<?>> handleBaseException(BaseException e) {
         return ResponseEntity.status(e.getStatus())
-                .body(ResponseDTO.fail(e.getErrorCode(), e.getMessage()));
+                .body(Response.fail(e.getErrorCode(), e.getMessage()));
     }
 
     // TODO: 그 외 비즈니스 로직 아닌 에러 중 분기처리 필요한 건 추가 (SQLException)

--- a/src/main/java/com/waguwagu/weat/global/model/AIErrorResponse.java
+++ b/src/main/java/com/waguwagu/weat/global/model/AIErrorResponse.java
@@ -1,4 +1,4 @@
-package com.waguwagu.weat.domain.common.dto;
+package com.waguwagu.weat.global.model;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/waguwagu/weat/global/model/Response.java
+++ b/src/main/java/com/waguwagu/weat/global/model/Response.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Schema(description = "공통 응답 DTO")
-public class ResponseDTO<T> {
+public class Response<T> {
 
     @Schema(description = "응답 코드", example = "SUCCESS")
     private String code;
@@ -21,30 +21,30 @@ public class ResponseDTO<T> {
     @Schema(description = "응답 데이터")
     private T data;
 
-    public ResponseDTO<T> code(String code) {
+    public Response<T> code(String code) {
         this.code = code;
         return this;
     }
 
-    public ResponseDTO<T> message(String message) {
+    public Response<T> message(String message) {
         this.message = message;
         return this;
     }
 
-    public ResponseDTO<T> data(T data) {
+    public Response<T> data(T data) {
         this.data = data;
         return this;
     }
 
-    public static <T> ResponseDTO<T> of(T data) {
-        return new ResponseDTO<T>()
+    public static <T> Response<T> of(T data) {
+        return new Response<T>()
                 .code(ErrorCode.SUCCESS.getCode())
                 .message(ErrorCode.SUCCESS.getMessage())
                 .data(data);
     }
 
-    public static <T> ResponseDTO<T> fail(String code, String message) {
-        return new ResponseDTO<T>()
+    public static <T> Response<T> fail(String code, String message) {
+        return new Response<T>()
                 .code(code)
                 .message(message)
                 .data(null);

--- a/src/main/java/com/waguwagu/weat/global/model/ResponseDTO.java
+++ b/src/main/java/com/waguwagu/weat/global/model/ResponseDTO.java
@@ -1,9 +1,7 @@
-package com.waguwagu.weat.domain.common.dto;
+package com.waguwagu.weat.global.model;
 
 import com.waguwagu.weat.global.exception.ErrorCode;
 import io.swagger.v3.oas.annotations.media.Schema;
-import org.springframework.http.HttpStatus;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/waguwagu/weat/global/utils/JsonbUtils.java
+++ b/src/main/java/com/waguwagu/weat/global/utils/JsonbUtils.java
@@ -1,4 +1,4 @@
-package com.waguwagu.weat.domain.common.utils;
+package com.waguwagu.weat.global.utils;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;


### PR DESCRIPTION
## 🔥 Refactoring PR

### 📌 개요
- 공통 클래스를 관리하는 패키지를 하나로 통일
- 공통 API 응답 클래스를 도메인 요청/응답 DTO와 명확하게 분리하기 위해 클래스 이름에서 DTO postfix 제거

### ✅ 주요 변경 사항
- [x] 기존 `com.waguwagu.weat.domain.common` 패키지 하위 공통 클래스를 `com.waguwagu.weat.global`로 이동
- [x] 공통 응답 클래스명 변경 (`ResponseDTO` -> `Response`)

### 📂 관련 이슈
- Relates: #85 

### 📝 비고
- 없음