### PR TITLE
feature/analysis/event - 분석 서비스에서 AI 분석 요청 시 이벤트 기반으로 변경 및 트랜잭션 커밋 이후 요청하도록 수정 

### DIFF
--- a/src/main/java/com/waguwagu/weat/domain/analysis/event/AnalysisStartEvent.java
+++ b/src/main/java/com/waguwagu/weat/domain/analysis/event/AnalysisStartEvent.java
@@ -1,0 +1,11 @@
+package com.waguwagu.weat.domain.analysis.event;
+
+import com.waguwagu.weat.domain.analysis.model.dto.AIAnalysisDTO.Request.MemberSetting;
+
+import java.util.List;
+
+public record AnalysisStartEvent(
+        String groupId,
+        Long analysisId,
+        List<MemberSetting> memberSettingList) {
+}

--- a/src/main/java/com/waguwagu/weat/domain/analysis/handler/AnalysisStartEventHandler.java
+++ b/src/main/java/com/waguwagu/weat/domain/analysis/handler/AnalysisStartEventHandler.java
@@ -1,0 +1,28 @@
+package com.waguwagu.weat.domain.analysis.handler;
+
+import com.waguwagu.weat.domain.analysis.event.AnalysisStartEvent;
+import com.waguwagu.weat.domain.analysis.model.dto.AIAnalysisDTO;
+import com.waguwagu.weat.domain.analysis.service.AnalysisAsyncExecutor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class AnalysisStartEventHandler {
+    private final AnalysisAsyncExecutor executor;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleAnalysisStartEvent(AnalysisStartEvent event) {
+        executor.startAnalysisAsync(
+                AIAnalysisDTO.Request.builder()
+                        .groupId(event.groupId())
+                        .analysisId(event.analysisId())
+                        .memberSettingList(event.memberSettingList())
+                        .build()
+        );
+    }
+}

--- a/src/main/java/com/waguwagu/weat/domain/analysis/service/AnalysisService.java
+++ b/src/main/java/com/waguwagu/weat/domain/analysis/service/AnalysisService.java
@@ -1,6 +1,7 @@
 package com.waguwagu.weat.domain.analysis.service;
 
 import com.waguwagu.weat.domain.analysis.adaptor.AIServiceAdaptor;
+import com.waguwagu.weat.domain.analysis.event.AnalysisStartEvent;
 import com.waguwagu.weat.domain.analysis.exception.*;
 import com.waguwagu.weat.domain.analysis.model.dto.*;
 import com.waguwagu.weat.domain.analysis.model.entity.*;
@@ -19,6 +20,7 @@ import com.waguwagu.weat.domain.group.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import reactor.core.publisher.Mono;
@@ -48,7 +50,7 @@ public class AnalysisService {
     private final CategoryTagRepository categoryTagRepository;
     private final AnalysisResultLikeRepository analysisResultLikeRepository;
     private final AnalysisResultDetailRepository analysisResultDetailRepository;
-
+    private final ApplicationEventPublisher eventPublisher;
 
     @Value("${ai.service.uri.validation}")
     private String validationUri;
@@ -248,13 +250,12 @@ public class AnalysisService {
             memberSettingList.add(memberSetting);
         }
 
-
-        // 비동기로 AI 분석서비스에 분석 요청
-        analysisAsyncExecutor.startAnalysisAsync(AIAnalysisDTO.Request.builder()
-                .groupId(group.getGroupId())
-                .analysisId(analysis.getAnalysisId())
-                .memberSettingList(memberSettingList)
-                .build());
+        // 트랜잭션 커밋 이후 AI 분석 요청
+        eventPublisher.publishEvent(new AnalysisStartEvent(
+                group.getGroupId(),
+                analysis.getAnalysisId(),
+                memberSettingList
+        ));
 
         return AnalysisStartDTO.Response.builder()
                 .groupId(group.getGroupId())


### PR DESCRIPTION
## 🔥 Feature PR

### 📌 개요
- 분석 서비스에서 분석 시작 시 AI 분석 요청 보내는 과정에서, 트랜잭션이 정상적으로 커밋된 경우에만 해당 요청이 보내지도록 수정하였습니다.

### ✅ 주요 변경 사항
- [x] 분석 시작 이벤트 정의
- [x] 분석 시작 이벤트 핸들러에서 트랜잭션 커밋 이후 AI 분석 요청 호출
- [x] 분석 시작 시 분석 서비스에서 이벤트 발행

### 📂 관련 이슈
- Relates
  - #93