### PR TITLE
refactor/analysisStatus - 그룹별 분석 설정 제출 수 조회 성능 개선 및 self-invocation 이슈 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'com.fasterxml.jackson.core:jackson-databind'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
-	compileOnly 'org.projectlombok:lombok'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testCompileOnly 'org.projectlombok:lombok'
 	testAnnotationProcessor 'org.projectlombok:lombok'
@@ -51,6 +52,7 @@ dependencies {
 	annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
 	annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
 	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+
 
 	testImplementation platform("org.testcontainers:testcontainers-bom:1.20.2")
 	testImplementation "org.testcontainers:junit-jupiter"

--- a/src/main/java/com/waguwagu/weat/domain/analysis/model/dto/AnalysisStartDTO.java
+++ b/src/main/java/com/waguwagu/weat/domain/analysis/model/dto/AnalysisStartDTO.java
@@ -1,14 +1,16 @@
 package com.waguwagu.weat.domain.analysis.model.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Builder;
-import lombok.Getter;
+import lombok.*;
 
 @Getter
 @Schema(description = "분석 시작 DTO")
 public class AnalysisStartDTO {
 
     @Getter
+    @Builder
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
     @Schema(description = "분석 시작 요청")
     public static class Request {
         @Schema(description = "그룹 식별자", example = "f5d8931a830e41968663ce0dc12bf9b2")

--- a/src/main/java/com/waguwagu/weat/domain/analysis/model/dto/GetAnalysisStatusDTO.java
+++ b/src/main/java/com/waguwagu/weat/domain/analysis/model/dto/GetAnalysisStatusDTO.java
@@ -1,6 +1,7 @@
 package com.waguwagu.weat.domain.analysis.model.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.waguwagu.weat.domain.analysis.model.entity.AnalysisStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
@@ -21,7 +22,7 @@ public class GetAnalysisStatusDTO {
         private Boolean isSingleMemberGroup;
 
         @Schema(description = "그룹 내 설정을 제출한 멤버 수", example = "2")
-        private int submittedCount;
+        private Long submittedCount;
 
         @Schema(description = "분석시작조건 충족 여부", example = "true")
         @JsonProperty("isAnalysisStartConditionSatisfied")
@@ -29,6 +30,6 @@ public class GetAnalysisStatusDTO {
 
         @Schema(description = "분석 진행 상태", example = "NOT_STARTED")
         @JsonProperty("analysisStatus")
-        private String analysisStatus;
+        private AnalysisStatus analysisStatus;
     }
 }

--- a/src/main/java/com/waguwagu/weat/domain/analysis/policy/AnalysisSettingSubmitPolicy.java
+++ b/src/main/java/com/waguwagu/weat/domain/analysis/policy/AnalysisSettingSubmitPolicy.java
@@ -20,8 +20,8 @@ public class AnalysisSettingSubmitPolicy {
      *
      * <p>분석 설정 제출이 가능한 상태인지 검증하고, 만족하지 못하는 조건이 있는 경우 예외 발생시킨다.</p>
      */
-    public void validate(Long memberId) {
-        if (memberRepository.existsById(memberId)) {
+    public void validate(long memberId) {
+        if (!memberRepository.existsById(memberId)) {
             throw new MemberNotFoundException(memberId);
         }
 

--- a/src/main/java/com/waguwagu/weat/domain/analysis/policy/AnalysisSettingSubmitPolicy.java
+++ b/src/main/java/com/waguwagu/weat/domain/analysis/policy/AnalysisSettingSubmitPolicy.java
@@ -1,0 +1,50 @@
+package com.waguwagu.weat.domain.analysis.policy;
+
+import com.waguwagu.weat.domain.analysis.exception.MemberAlreadySubmitSettingForMemberIdException;
+import com.waguwagu.weat.domain.analysis.exception.MemberNotFoundException;
+import com.waguwagu.weat.domain.analysis.repository.AnalysisSettingRepository;
+import com.waguwagu.weat.domain.group.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AnalysisSettingSubmitPolicy {
+    private final MemberRepository memberRepository;
+    private final AnalysisSettingRepository analysisSettingRepository;
+
+    /**
+     * 분석설정 제출이 가능한 상태인지 검증
+     *
+     * <p>분석 설정 제출이 가능한 상태인지 검증하고, 만족하지 못하는 조건이 있는 경우 예외 발생시킨다.</p>
+     */
+    public void validate(Long memberId) {
+        if (memberRepository.existsById(memberId)) {
+            throw new MemberNotFoundException(memberId);
+        }
+
+        // 멤버가 기존에 설정을 제출했는지 여부 확인
+        boolean alreadySubmitted = analysisSettingRepository.existsByMemberMemberId(memberId);
+
+        // 이미 제출한 경우 예외 발생
+        if (!SubmitCriteria.SUBMITTABLE.isSatisfied(alreadySubmitted)) {
+            throw new MemberAlreadySubmitSettingForMemberIdException(memberId);
+        }
+    }
+
+    /**
+     * 제출 가능한 상태에 대한 기준
+     *
+     * <p>분석 설정을 제출하기 위해서는 기존에 제출한 상태가 아니어야 한다.</p>
+     */
+    public enum SubmitCriteria {
+        SUBMITTABLE;
+
+        // 기존에 제출한 상태가 아니어야만 제출 가능
+        public boolean isSatisfied(boolean alreadySubmitted) {
+            return !alreadySubmitted;
+        }
+    }
+}

--- a/src/main/java/com/waguwagu/weat/domain/analysis/policy/AnalysisStartPolicy.java
+++ b/src/main/java/com/waguwagu/weat/domain/analysis/policy/AnalysisStartPolicy.java
@@ -9,14 +9,17 @@ import com.waguwagu.weat.domain.analysis.repository.AnalysisSettingRepository;
 import com.waguwagu.weat.domain.group.exception.GroupNotFoundException;
 import com.waguwagu.weat.domain.group.model.entity.Group;
 import com.waguwagu.weat.domain.group.repository.GroupRepository;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.validation.annotation.Validated;
 
 import java.util.EnumSet;
 import java.util.Set;
 
+@Validated
 @Component
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -28,7 +31,7 @@ public class AnalysisStartPolicy {
      *
      * <p>분석 시작을 위해 필요한 조건들은 평가한다.</p>
      */
-    public Result evaluate(String groupId) {
+    public Result evaluate(@NotNull String groupId) {
         boolean isSubmittedConditionSatisfied = support.evaluateSubmittedCondition(groupId);
         boolean isAnalysisStatusConditionSatisfied = support.evaluateAnalysisStatusCondition(groupId);
         boolean isSatisfied = isSubmittedConditionSatisfied && isAnalysisStatusConditionSatisfied;
@@ -45,7 +48,7 @@ public class AnalysisStartPolicy {
      *
      * <p>분석 시작이 가능한지 검증하고, 만족하지 못하는 조건이 있는 경우 예외를 발생시킨다.</p>
      */
-    public void validate(String groupId) {
+    public void validate(@NotNull String groupId) {
         if (!support.evaluateAnalysisStatusCondition(groupId)) {
             throw new AnalysisAlreadyStartedForGroupIdException(groupId);
         }
@@ -69,6 +72,7 @@ public class AnalysisStartPolicy {
     ) {
     }
 
+    @Validated
     @Component
     @RequiredArgsConstructor
     @Transactional(readOnly = true)
@@ -84,7 +88,7 @@ public class AnalysisStartPolicy {
          *
          * @see AnalysisStartPolicy.SubmitCriteria
          */
-        public boolean evaluateSubmittedCondition(String groupId) {
+        public boolean evaluateSubmittedCondition(@NotNull String groupId) {
             Group group = groupRepository.findById(groupId)
                     .orElseThrow(() -> new GroupNotFoundException(groupId));
 
@@ -103,7 +107,7 @@ public class AnalysisStartPolicy {
          *
          * @see AnalysisStartPolicy.StatusCriteria
          */
-        public boolean evaluateAnalysisStatusCondition(String groupId) {
+        public boolean evaluateAnalysisStatusCondition(@NotNull String groupId) {
             AnalysisStatus analysisStatus = analysisRepository.findByGroupGroupId(groupId)
                     .orElseThrow(() -> new AnalysisNotFoundForGroupIdException(groupId))
                     .getAnalysisStatus();
@@ -146,7 +150,7 @@ public class AnalysisStartPolicy {
         // 허용된 분석 상태 집합
         private final Set<AnalysisStatus> allowedStatuses;
 
-        public boolean isSatisfied(AnalysisStatus status) {
+        public boolean isSatisfied(@NotNull AnalysisStatus status) {
             return allowedStatuses.contains(status);
         }
     }

--- a/src/main/java/com/waguwagu/weat/domain/analysis/policy/AnalysisStartPolicy.java
+++ b/src/main/java/com/waguwagu/weat/domain/analysis/policy/AnalysisStartPolicy.java
@@ -1,0 +1,153 @@
+package com.waguwagu.weat.domain.analysis.policy;
+
+import com.waguwagu.weat.domain.analysis.exception.AnalysisAlreadyStartedForGroupIdException;
+import com.waguwagu.weat.domain.analysis.exception.AnalysisConditionNotSatisfiedForGroupIdException;
+import com.waguwagu.weat.domain.analysis.exception.AnalysisNotFoundForGroupIdException;
+import com.waguwagu.weat.domain.analysis.model.entity.AnalysisStatus;
+import com.waguwagu.weat.domain.analysis.repository.AnalysisRepository;
+import com.waguwagu.weat.domain.analysis.repository.AnalysisSettingRepository;
+import com.waguwagu.weat.domain.group.exception.GroupNotFoundException;
+import com.waguwagu.weat.domain.group.model.entity.Group;
+import com.waguwagu.weat.domain.group.repository.GroupRepository;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AnalysisStartPolicy {
+    private final AnalysisStartPolicySupport support;
+
+    /**
+     * 분석시작가능 여부 평가
+     *
+     * <p>분석 시작을 위해 필요한 조건들은 평가한다.</p>
+     */
+    public Result evaluate(String groupId) {
+        boolean isSubmittedConditionSatisfied = support.evaluateSubmittedCondition(groupId);
+        boolean isAnalysisStatusConditionSatisfied = support.evaluateAnalysisStatusCondition(groupId);
+        boolean isSatisfied = isSubmittedConditionSatisfied && isAnalysisStatusConditionSatisfied;
+
+        return new Result(
+                isSatisfied,
+                isSubmittedConditionSatisfied,
+                isAnalysisStatusConditionSatisfied
+        );
+    }
+
+    /**
+     * 분석시작가능 여부 검증
+     *
+     * <p>분석 시작이 가능한지 검증하고, 만족하지 못하는 조건이 있는 경우 예외를 발생시킨다.</p>
+     */
+    public void validate(String groupId) {
+        if (!support.evaluateAnalysisStatusCondition(groupId)) {
+            throw new AnalysisAlreadyStartedForGroupIdException(groupId);
+        }
+
+        if (!support.evaluateSubmittedCondition(groupId)) {
+            throw new AnalysisConditionNotSatisfiedForGroupIdException(groupId);
+        }
+    }
+
+    /**
+     * 분석시작가능 여부 평가 결과
+     *
+     * <p>분석시작가능 여부 평가 후 각 조건들에 대한 충족 여부를 반환하기 위한 레코드</p>
+     *
+     * @see AnalysisStartPolicy#evaluate
+     */
+    public record Result(
+            boolean isSatisfied, // 전체조건 충족 여부
+            boolean isSubmittedConditionSatisfied, // 설정제출조건 충족 여부
+            boolean isAnalysisStatusConditionSatisfied // 분석상태조건 충족 여부
+    ) {
+    }
+
+    @Component
+    @RequiredArgsConstructor
+    @Transactional(readOnly = true)
+    public static class AnalysisStartPolicySupport {
+        private final GroupRepository groupRepository;
+        private final AnalysisRepository analysisRepository;
+        private final AnalysisSettingRepository analysisSettingRepository;
+
+        /**
+         * 분석 시작을 위한 분석설정제출 조건 평가
+         *
+         * <p>분석설정제출 기준에 따라 분석 시작이 가능한지 평가한다.</p>
+         *
+         * @see AnalysisStartPolicy.SubmitCriteria
+         */
+        public boolean evaluateSubmittedCondition(String groupId) {
+            Group group = groupRepository.findById(groupId)
+                    .orElseThrow(() -> new GroupNotFoundException(groupId));
+
+            SubmitCriteria submitCriteria = group.isSingleMemberGroup() ?
+                    SubmitCriteria.SINGLE_MEMBER_GROUP : SubmitCriteria.MULTI_MEMBER_GROUP;
+
+            long submittedCount = analysisSettingRepository.countAnalysisSettingByGroupId(groupId);
+
+            return submitCriteria.isSatisfied(submittedCount);
+        }
+
+        /**
+         * 분석 시작을 위한 분석상태 조건 평가
+         *
+         * <p>분석상태 기준에 따라 분석 시작이 가능한지 평가한다.</p>
+         *
+         * @see AnalysisStartPolicy.StatusCriteria
+         */
+        public boolean evaluateAnalysisStatusCondition(String groupId) {
+            AnalysisStatus analysisStatus = analysisRepository.findByGroupGroupId(groupId)
+                    .orElseThrow(() -> new AnalysisNotFoundForGroupIdException(groupId))
+                    .getAnalysisStatus();
+
+            return StatusCriteria.STARTABLE.isSatisfied(analysisStatus);
+        }
+    }
+
+    /**
+     * 분석 시작을 위한 분석 설정 제출에 대한 기준
+     *
+     * <p>분석 시작을 위해서는 반드시 그룹 유형별로 일정 수 이상의 분석 설정이 제출되어야 한다.</p>
+     */
+    @Getter
+    @RequiredArgsConstructor
+    public enum SubmitCriteria {
+        SINGLE_MEMBER_GROUP(1L),
+        MULTI_MEMBER_GROUP(2L);
+
+        // 분석 설정 제출 인원수에 대한 기준
+        private final long requiredCount;
+
+        // 단일멤버그룹 또는 다중멤버그룹 여부에 따라서 일정 수 이상 설정을 제출해야 만족
+        public boolean isSatisfied(long submittedCount) {
+            return submittedCount >= requiredCount;
+        }
+    }
+
+    /**
+     * 분석 시작을 위한 분석 상태에 대한 기준
+     *
+     * <p>분석 시작을 위해서는 반드시 그룹의 분석상태가 "분석시작전"(AnalysisStatus.NOT_STARTED) 상태이어야 한다.</p>
+     */
+    @Getter
+    @RequiredArgsConstructor
+    public enum StatusCriteria {
+        // 분석 시작이 가능한 상태 정의 (분석이 아직 시작되지 않은 경우에만 허용)
+        STARTABLE(EnumSet.of(AnalysisStatus.NOT_STARTED));
+
+        // 허용된 분석 상태 집합
+        private final Set<AnalysisStatus> allowedStatuses;
+
+        public boolean isSatisfied(AnalysisStatus status) {
+            return allowedStatuses.contains(status);
+        }
+    }
+}

--- a/src/main/java/com/waguwagu/weat/domain/analysis/repository/AnalysisSettingRepositoryCustom.java
+++ b/src/main/java/com/waguwagu/weat/domain/analysis/repository/AnalysisSettingRepositoryCustom.java
@@ -6,4 +6,5 @@ import java.util.List;
 
 public interface AnalysisSettingRepositoryCustom {
     List<MemberAnalysisSettingDTO> findMemberAnalysisSettingsByGroupId(String groupId);
+    Long countAnalysisSettingByGroupId(String groupId);
 }

--- a/src/main/java/com/waguwagu/weat/domain/analysis/repository/AnalysisSettingRepositoryImpl.java
+++ b/src/main/java/com/waguwagu/weat/domain/analysis/repository/AnalysisSettingRepositoryImpl.java
@@ -89,4 +89,23 @@ public class AnalysisSettingRepositoryImpl implements AnalysisSettingRepositoryC
 
         return new ArrayList<>(memberMap.values());
     }
+
+    /**
+     * 그룹별 제출된 분석설정 개수 조회
+     * <p>그룹내의 멤버들에 의해 제출된 분석 설정 개수를 조회한다.</p>
+     */
+    public Long countAnalysisSettingByGroupId(String groupId) {
+
+        Objects.requireNonNull(groupId, "groupId must not be null");
+
+        QAnalysisSetting as = QAnalysisSetting.analysisSetting;
+        QMember m = QMember.member;
+
+        return queryFactory
+                .select(as.member.memberId.count())
+                .from(as)
+                .join(as.member, m)
+                .where(m.group.groupId.eq(groupId))
+                .fetchOne();
+    }
 }

--- a/src/main/java/com/waguwagu/weat/domain/analysis/service/AnalysisService.java
+++ b/src/main/java/com/waguwagu/weat/domain/analysis/service/AnalysisService.java
@@ -164,42 +164,25 @@ public class AnalysisService {
                 .build();
     }
 
-    // TODO: 개발 진행중, AI 분석 서비스 응답 형식 정해지면 재개
     public AnalysisStartDTO.Response analysisStart(AnalysisStartDTO.Request request) {
 
-        var groupId = request.getGroupId();
-
         // 그룹 조회
-        Group group = groupRepository.findById(groupId)
-                .orElseThrow(() -> new GroupNotFoundException(groupId));
+        Group group = groupRepository.findById(request.getGroupId())
+                .orElseThrow(() -> new GroupNotFoundException(request.getGroupId()));
 
-
-        var analysisStartAvailable = getAnalysisStatus(groupId);
-
-        if (!analysisStartAvailable.getAnalysisStatus().equals(AnalysisStatus.NOT_STARTED.toString())) {
-            throw new AnalysisAlreadyStartedForGroupIdException(groupId);
-        }
-
-        if (!analysisStartAvailable.getIsAnalysisStartConditionSatisfied()) {
-            throw new AnalysisConditionNotSatisfiedForGroupIdException(groupId);
-        }
+        // 분석시작조건 충족 여부 확인
+        analysisStartPolicy.validate(group.getGroupId());
 
         // 그룹에 대한 분석정보 조회
         Analysis analysis = analysisRepository.findByGroupGroupId(group.getGroupId())
                 .orElseThrow(() -> new AnalysisNotFoundForGroupIdException(group.getGroupId()));
 
-        // 이미 진행중인 분석인지 확인
-        if (!analysis.getAnalysisStatus().equals(AnalysisStatus.NOT_STARTED)) {
-            // 이미 진행중이라면 208 응답 반환
-            throw new AnalysisAlreadyStartedForGroupIdException(groupId);
-        }
-
-        // 진행중이지 않다면, "진행중" 상태로 변경
+        // "진행중" 상태로 변경
         analysis.setAnalysisStatus(AnalysisStatus.IN_PROGRESS);
 
         // 그룹에 속한 멤버들의 분석 설정 일괄 조회
         List<MemberAnalysisSettingDTO> groupMemberSettings =
-                analysisSettingRepository.findMemberAnalysisSettingsByGroupId(groupId);
+                analysisSettingRepository.findMemberAnalysisSettingsByGroupId(group.getGroupId());
 
         // AI 분석 시작 요청에 사용되는 객체로 변환
         List<AIAnalysisDTO.Request.MemberSetting> memberSettingList = groupMemberSettings.stream()

--- a/src/main/java/com/waguwagu/weat/domain/analysis/service/AnalysisService.java
+++ b/src/main/java/com/waguwagu/weat/domain/analysis/service/AnalysisService.java
@@ -89,7 +89,7 @@ public class AnalysisService {
 
     // 멤버별 분석 설정 제출 여부 조회
     public IsMemberSubmitAnalysisSettingDTO.Response isMemberSubmitAnalysisSetting(Long memberId) {
-
+        // 멤버 정보 조회
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberNotFoundException(memberId));
 
@@ -103,14 +103,12 @@ public class AnalysisService {
 
     // 멤버별 분석 설정 제출
     public SubmitAnalysisSettingDTO.Response submitAnalysisSetting(SubmitAnalysisSettingDTO.Request requestDto) {
-        // 회원 정보 조회
+        // 멤버 정보 조회
         Member member = memberRepository.findById(requestDto.getMemberId())
                 .orElseThrow(() -> new MemberNotFoundException(requestDto.getMemberId()));
 
-        // 이미 제출한 회원인 경우
-        if (isMemberSubmitAnalysisSetting(requestDto.getMemberId()).isSubmitted()) {
-            throw new MemberAlreadySubmitSettingForMemberIdException(member.getMemberId());
-        }
+        // 멤버가 분석 설정을 제출할 수 있는 상태인지 검증
+        analysisSettingSubmitPolicy.validate(member.getMemberId());
 
         // 분석 정보 조회
         Analysis analysis = analysisRepository.findByGroupGroupId(member.getGroup().getGroupId())
@@ -122,6 +120,7 @@ public class AnalysisService {
                 .member(member)
                 .build();
 
+        // 설정 정보 저장
         analysisSettingRepository.save(analysisSetting);
 
         // 위치 설정

--- a/src/main/java/com/waguwagu/weat/domain/analysis/service/AnalysisService.java
+++ b/src/main/java/com/waguwagu/weat/domain/analysis/service/AnalysisService.java
@@ -2,9 +2,14 @@ package com.waguwagu.weat.domain.analysis.service;
 
 import com.waguwagu.weat.domain.analysis.adaptor.AIServiceAdaptor;
 import com.waguwagu.weat.domain.analysis.event.AnalysisStartEvent;
-import com.waguwagu.weat.domain.analysis.exception.*;
+import com.waguwagu.weat.domain.analysis.exception.AnalysisNotFoundForGroupIdException;
+import com.waguwagu.weat.domain.analysis.exception.AnalysisResultDetailNotFoundException;
+import com.waguwagu.weat.domain.analysis.exception.MemberAlreadySubmitSettingForMemberIdException;
+import com.waguwagu.weat.domain.analysis.exception.MemberNotFoundException;
 import com.waguwagu.weat.domain.analysis.model.dto.*;
 import com.waguwagu.weat.domain.analysis.model.entity.*;
+import com.waguwagu.weat.domain.analysis.policy.AnalysisSettingSubmitPolicy;
+import com.waguwagu.weat.domain.analysis.policy.AnalysisStartPolicy;
 import com.waguwagu.weat.domain.analysis.repository.*;
 import com.waguwagu.weat.domain.category.exception.CategoryTagNotFoundException;
 import com.waguwagu.weat.domain.category.model.entity.CategoryTag;
@@ -15,20 +20,24 @@ import com.waguwagu.weat.domain.group.model.entity.Group;
 import com.waguwagu.weat.domain.group.model.entity.Member;
 import com.waguwagu.weat.domain.group.repository.GroupRepository;
 import com.waguwagu.weat.domain.group.repository.MemberRepository;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.validation.annotation.Validated;
 import reactor.core.publisher.Mono;
 
 import java.time.Duration;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
+@Validated
 @Transactional
 @RequiredArgsConstructor
 public class AnalysisService {
@@ -36,51 +45,43 @@ public class AnalysisService {
     private final AIServiceAdaptor aiServiceAdaptor;
     private final GroupRepository groupRepository;
     private final MemberRepository memberRepository;
-    private final CategoryRepository categoryRepository;
     private final AnalysisRepository analysisRepository;
     private final AnalysisSettingRepository analysisSettingRepository;
     private final AnalysisSettingDetailRepository analysisSettingDetailRepository;
-    private final AnalysisAsyncExecutor analysisAsyncExecutor;
-    private final TextInputSettingRepository textInputSettingRepository;
-    private final LocationSettingRepository locationSettingRepository;
-    private final CategorySettingRepository categorySettingRepository;
     private final CategoryTagRepository categoryTagRepository;
     private final AnalysisResultLikeRepository analysisResultLikeRepository;
     private final AnalysisResultDetailRepository analysisResultDetailRepository;
     private final ApplicationEventPublisher eventPublisher;
+    private final AnalysisStartPolicy analysisStartPolicy;
+    private final AnalysisSettingSubmitPolicy analysisSettingSubmitPolicy;
 
     @Value("${ai.service.uri.validation}")
     private String validationUri;
 
     private static final Duration AI_TIMEOUT = Duration.ofSeconds(60);
 
-    // 분석 시작가능조건 충족여부 및 분석상태 조회
-    public GetAnalysisStatusDTO.Response getAnalysisStatus(String groupId) {
+    public GetAnalysisStatusDTO.Response getAnalysisStatus(@NotNull String groupId) {
 
-        final int GROUP_CRITERIA = 2;
-        final int SINGLE_CRITERIA = 1;
-
+        // 그룹 정보 조회
         Group group = groupRepository.findById(groupId)
                 .orElseThrow(() -> new GroupNotFoundException(groupId));
 
-        String analysisStatus = analysisRepository.findByGroupGroupId(groupId)
+        // 그룹의 분석상태 조회
+        AnalysisStatus analysisStatus = analysisRepository.findByGroupGroupId(groupId)
                 .orElseThrow(() -> new AnalysisNotFoundForGroupIdException(groupId))
-                .getAnalysisStatus().toString();
+                .getAnalysisStatus();
 
-        List<Member> memberList = memberRepository.findAllByGroupGroupId(groupId);
+        // 그룹내의 설정 제출 수
+        Long submittedCount = analysisSettingRepository.countAnalysisSettingByGroupId(groupId);
 
-        int submittedCount = (int) memberList.stream()
-                .filter(member -> analysisSettingRepository.existsByMemberMemberId(member.getMemberId()))
-                .count();
-
-        int criteria = group.isSingleMemberGroup() ? SINGLE_CRITERIA : GROUP_CRITERIA;
-        boolean isSatisfied = submittedCount >= criteria;
+        // 분석시작가능 여부 평가
+        AnalysisStartPolicy.Result analysisStartPolicyEvaluateteResult = analysisStartPolicy.evaluate(groupId);
 
         return GetAnalysisStatusDTO.Response.builder()
                 .groupId(group.getGroupId())
                 .isSingleMemberGroup(group.isSingleMemberGroup())
                 .submittedCount(submittedCount)
-                .isAnalysisStartConditionSatisfied(isSatisfied)
+                .isAnalysisStartConditionSatisfied(analysisStartPolicyEvaluateteResult.isSatisfied())
                 .analysisStatus(analysisStatus)
                 .build();
     }

--- a/src/test/java/com/waguwagu/weat/domain/analysis/handler/AnalysisStartEventHandlerTest.java
+++ b/src/test/java/com/waguwagu/weat/domain/analysis/handler/AnalysisStartEventHandlerTest.java
@@ -1,0 +1,168 @@
+package com.waguwagu.weat.domain.analysis.handler;
+
+import com.waguwagu.weat.domain.analysis.event.AnalysisStartEvent;
+import com.waguwagu.weat.domain.analysis.model.dto.AIAnalysisDTO;
+import com.waguwagu.weat.domain.analysis.service.AnalysisAsyncExecutor;
+import com.waguwagu.weat.global.TestContainersConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.*;
+
+@ActiveProfiles("test")
+@Import({TestContainersConfig.class})
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@SpringBootTest
+public class AnalysisStartEventHandlerTest {
+
+    @Autowired
+    ApplicationEventPublisher applicationEventPublisher;
+
+    @Autowired
+    PlatformTransactionManager platformTransactionManager;
+
+    @SpyBean
+    AnalysisStartEventHandler analysisStartEventHandler;
+
+    @SpyBean
+    AnalysisAsyncExecutor analysisAsyncExecutor;
+
+    @Nested
+    @DisplayName("handleAnalysisStartEvent")
+    class HandleAnalysisStartEvent {
+
+        @Nested
+        @DisplayName("SUCCESS")
+        class SuccessTest {
+
+            @Test
+            @DisplayName("이벤트 발행 후 트랜잭션이 커밋되면 이벤트 핸들러가 실행되어야 한다.")
+            void handleAnalysisStartEvent_success_tc_01() {
+                // given
+                final TransactionTemplate transactionTemplate = new TransactionTemplate(platformTransactionManager);
+
+                final List<AIAnalysisDTO.Request.MemberSetting> givenMemberSettingList =
+                        List.of(mock(AIAnalysisDTO.Request.MemberSetting.class),
+                                mock(AIAnalysisDTO.Request.MemberSetting.class));
+
+                final AnalysisStartEvent givenEvent = new AnalysisStartEvent("test", 0L, givenMemberSettingList);
+
+                doNothing().when(analysisAsyncExecutor)
+                        .startAnalysisAsync(any(AIAnalysisDTO.Request.class));
+
+                // when
+                transactionTemplate.executeWithoutResult(transactionStatus -> {
+                    applicationEventPublisher.publishEvent(givenEvent);
+                });
+
+                // then
+                final ArgumentCaptor<AIAnalysisDTO.Request> aiAnalysisRequestCaptor = ArgumentCaptor.forClass(AIAnalysisDTO.Request.class);
+                verify(analysisStartEventHandler).handleAnalysisStartEvent(givenEvent);
+                verify(analysisAsyncExecutor).startAnalysisAsync(aiAnalysisRequestCaptor.capture());
+
+                final AIAnalysisDTO.Request aiAnalysisRequest = aiAnalysisRequestCaptor.getValue();
+                assertThat(aiAnalysisRequest.getGroupId()).isEqualTo(givenEvent.groupId());
+                assertThat(aiAnalysisRequest.getAnalysisId()).isEqualTo(givenEvent.analysisId());
+                assertThat(aiAnalysisRequest.getMemberSettingList()).hasSize(givenMemberSettingList.size());
+            }
+
+
+            @Test
+            @DisplayName("이벤트 발행 후 트랜잭션이 롤백되면 이벤트 핸들러가 실행되지 않아야 한다.")
+            void handleAnalysisStartEvent_success_tc_02() {
+                // given
+                final TransactionTemplate transactionTemplate = new TransactionTemplate(platformTransactionManager);
+
+                final List<AIAnalysisDTO.Request.MemberSetting> givenMemberSettingList =
+                        List.of(mock(AIAnalysisDTO.Request.MemberSetting.class),
+                                mock(AIAnalysisDTO.Request.MemberSetting.class));
+
+                final AnalysisStartEvent givenEvent = new AnalysisStartEvent("test", 0L, givenMemberSettingList);
+
+                // when
+                transactionTemplate.executeWithoutResult(
+                        transactionStatus -> {
+                            applicationEventPublisher.publishEvent(givenEvent);
+                            transactionStatus.setRollbackOnly();
+                        });
+
+                // then
+                verify(analysisStartEventHandler, never()).handleAnalysisStartEvent(any(AnalysisStartEvent.class));
+                verify(analysisAsyncExecutor, never()).startAnalysisAsync(any(AIAnalysisDTO.Request.class));
+            }
+
+            @Test
+            @DisplayName("트랜잭션 밖에서는 이벤트가 발행되어도 핸들러가 실행되지 않아야 한다.")
+            void handleAnalysisStartEvent_success_tc_03() {
+                // given
+                final List<AIAnalysisDTO.Request.MemberSetting> givenMemberSettingList =
+                        List.of(mock(AIAnalysisDTO.Request.MemberSetting.class),
+                                mock(AIAnalysisDTO.Request.MemberSetting.class));
+
+                final AnalysisStartEvent givenEvent = new AnalysisStartEvent("test", 0L, givenMemberSettingList);
+
+                // when
+                applicationEventPublisher.publishEvent(givenEvent);
+
+                // then
+                verify(analysisStartEventHandler, never()).handleAnalysisStartEvent(any());
+                verify(analysisAsyncExecutor, never()).startAnalysisAsync(any());
+            }
+        }
+
+        @Nested
+        @DisplayName("EXCEPTION")
+        class ExceptionTest {
+            @Test
+            @DisplayName("핸들러 내부에서 예외가 발생해도 트랜잭션에는 영향을 주지 않아야 한다.")
+            void handleAnalysisStartEvent_exception_tc_01() {
+                // given
+                final TransactionTemplate transactionTemplate = new TransactionTemplate(platformTransactionManager);
+                final AnalysisStartEvent givenEvent =
+                        new AnalysisStartEvent("test", 0L,
+                                List.of(mock(AIAnalysisDTO.Request.MemberSetting.class)));
+
+                doThrow(new RuntimeException("test exception"))
+                        .when(analysisStartEventHandler)
+                        .handleAnalysisStartEvent(any());
+
+                AtomicBoolean committed = new AtomicBoolean(false);
+
+                // when & then
+                assertDoesNotThrow(() ->
+                        transactionTemplate.executeWithoutResult(
+                                transactionStatus -> {
+                                    TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                                        @Override
+                                        public void afterCompletion(int status) {
+                                            committed.set(status == TransactionSynchronization.STATUS_COMMITTED);
+                                        }
+                                    });
+                                    applicationEventPublisher.publishEvent(givenEvent);
+                                })
+                );
+
+                assertThat(committed).isTrue();
+                verify(analysisStartEventHandler).handleAnalysisStartEvent(givenEvent);
+            }
+        }
+    }
+}

--- a/src/test/java/com/waguwagu/weat/domain/analysis/policy/AnalysisSettingSubmitPolicyTest.java
+++ b/src/test/java/com/waguwagu/weat/domain/analysis/policy/AnalysisSettingSubmitPolicyTest.java
@@ -1,0 +1,77 @@
+package com.waguwagu.weat.domain.analysis.policy;
+
+import com.waguwagu.weat.domain.analysis.exception.MemberAlreadySubmitSettingForMemberIdException;
+import com.waguwagu.weat.domain.analysis.repository.AnalysisSettingRepository;
+import com.waguwagu.weat.domain.group.repository.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.validation.beanvalidation.MethodValidationPostProcessor;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {
+        AnalysisSettingSubmitPolicy.class,
+        MethodValidationPostProcessor.class
+})
+class AnalysisSettingSubmitPolicyTest {
+
+    @MockBean
+    MemberRepository memberRepository;
+
+    @MockBean
+    AnalysisSettingRepository analysisSettingRepository;
+
+    @Autowired
+    AnalysisSettingSubmitPolicy analysisSettingSubmitPolicy;
+
+    @Nested
+    @DisplayName("validate - 분석설정제출 가능 여부 검증")
+    class Validate {
+        @Nested
+        @DisplayName("SUCCESS")
+        class SuccessTest {
+
+            @Test
+            @DisplayName("분석 설정을 제출한적이 없는 멤버인 경우 예외가 발생하지 않아야 한다.")
+            void validate_success_tc_01() {
+                // given
+                final long givenMemberId = 0L;
+                when(memberRepository.existsById(givenMemberId)).thenReturn(true);
+                when(analysisSettingRepository.existsByMemberMemberId(givenMemberId)).thenReturn(false);
+
+                // when
+                assertDoesNotThrow(
+                        () -> analysisSettingSubmitPolicy.validate(givenMemberId)
+                );
+            }
+        }
+
+        @Nested
+        @DisplayName("EXCEPTION")
+        class ExceptionTest {
+            @Test
+            @DisplayName("분석 설정을 제출한적이 있는 멤버인 경우 `MemberAlreadySubmitSettingForMemberIdException` 예외가 발생해야 한다.")
+            void validate_exception_tc_01() {
+                // given
+                final long givenMemberId = 0L;
+                when(memberRepository.existsById(givenMemberId)).thenReturn(true);
+                when(analysisSettingRepository.existsByMemberMemberId(givenMemberId)).thenReturn(true);
+
+                // when
+                assertThrows(MemberAlreadySubmitSettingForMemberIdException.class,
+                        () -> analysisSettingSubmitPolicy.validate(givenMemberId)
+                );
+            }
+        }
+    }
+
+}

--- a/src/test/java/com/waguwagu/weat/domain/analysis/policy/AnalysisStartPolicySupportTest.java
+++ b/src/test/java/com/waguwagu/weat/domain/analysis/policy/AnalysisStartPolicySupportTest.java
@@ -1,0 +1,262 @@
+package com.waguwagu.weat.domain.analysis.policy;
+
+import com.waguwagu.weat.domain.analysis.exception.AnalysisNotFoundForGroupIdException;
+import com.waguwagu.weat.domain.analysis.model.entity.Analysis;
+import com.waguwagu.weat.domain.analysis.model.entity.AnalysisStatus;
+import com.waguwagu.weat.domain.analysis.repository.AnalysisRepository;
+import com.waguwagu.weat.domain.analysis.repository.AnalysisSettingRepository;
+import com.waguwagu.weat.domain.group.exception.GroupNotFoundException;
+import com.waguwagu.weat.domain.group.model.entity.Group;
+import com.waguwagu.weat.domain.group.repository.GroupRepository;
+import jakarta.validation.ConstraintViolationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.validation.beanvalidation.MethodValidationPostProcessor;
+
+import java.util.Optional;
+import java.util.Random;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {
+        AnalysisStartPolicy.AnalysisStartPolicySupport.class,
+        MethodValidationPostProcessor.class
+})
+class AnalysisStartPolicySupportTest {
+
+    @MockBean
+    GroupRepository groupRepository;
+
+    @MockBean
+    AnalysisRepository analysisRepository;
+
+    @MockBean
+    AnalysisSettingRepository analysisSettingRepository;
+
+    @Autowired
+    AnalysisStartPolicy.AnalysisStartPolicySupport analysisStartPolicySupport;
+
+    String testSingleMemberGroupId;
+    String testMultipleMemberGroupId;
+    Group testSingleMemberGroup;
+    Group testMultipleMemberGroup;
+
+    @BeforeEach
+    void setUp() {
+        testSingleMemberGroupId = UUID.randomUUID().toString().replace("-", "");
+        testSingleMemberGroup = Group.builder()
+                .groupId(testSingleMemberGroupId)
+                .isSingleMemberGroup(true)
+                .build();
+
+        testMultipleMemberGroupId = UUID.randomUUID().toString().replace("-", "");
+        testMultipleMemberGroup = Group.builder()
+                .groupId(testMultipleMemberGroupId)
+                .isSingleMemberGroup(false)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("evaluateSubmittedCondition - 분석설정제출 조건")
+    class EvaluateSubmittedCondition {
+
+        @Nested
+        @DisplayName("SUCCESS")
+        class SuccessTest {
+
+            @Test
+            @DisplayName("단일 멤버 그룹에서 설정을 제출한 멤버수가 1명인 경우 true를 반환해야한다.")
+            void evaluateSubmittedCondition_success_tc_01() {
+                // given
+                final long givenSubmittedCount = 1L;
+                when(groupRepository.findById(testSingleMemberGroupId)).thenReturn(Optional.of(testSingleMemberGroup));
+                when(analysisSettingRepository.countAnalysisSettingByGroupId(testSingleMemberGroupId)).thenReturn(givenSubmittedCount);
+
+                // when
+                final boolean result = analysisStartPolicySupport.evaluateSubmittedCondition(testSingleMemberGroupId);
+
+                // then
+                assertThat(result).isTrue();
+
+                verify(groupRepository).findById(testSingleMemberGroupId);
+                verify(analysisSettingRepository).countAnalysisSettingByGroupId(testSingleMemberGroupId);
+            }
+
+            @Test
+            @DisplayName("단일 멤버 그룹에서 설정을 제출한 멤버가 없을 경우 false를 반환해야한다.")
+            void evaluateSubmittedCondition_success_tc_02() {
+                // given
+                final long givenSubmittedCount = 0L;
+                when(groupRepository.findById(testSingleMemberGroupId)).thenReturn(Optional.of(testSingleMemberGroup));
+                when(analysisSettingRepository.countAnalysisSettingByGroupId(testSingleMemberGroupId)).thenReturn(givenSubmittedCount);
+
+                // when
+                final boolean result = analysisStartPolicySupport.evaluateSubmittedCondition(testSingleMemberGroupId);
+
+                // then
+                assertThat(result).isFalse();
+
+                verify(groupRepository).findById(testSingleMemberGroupId);
+                verify(analysisSettingRepository).countAnalysisSettingByGroupId(testSingleMemberGroupId);
+            }
+
+            @Test
+            @DisplayName("다중 멤버 그룹에서 설정을 제출한 멤버수가 2명 이상인 경우 true를 반환해야한다.")
+            void evaluateSubmittedCondition_success_tc_03() {
+                // given
+                final long givenSubmittedCount = 2 + new Random().nextInt(10);
+                when(groupRepository.findById(testMultipleMemberGroupId)).thenReturn(Optional.of(testMultipleMemberGroup));
+                when(analysisSettingRepository.countAnalysisSettingByGroupId(testMultipleMemberGroupId)).thenReturn(givenSubmittedCount);
+
+                // when
+                final boolean result = analysisStartPolicySupport.evaluateSubmittedCondition(testMultipleMemberGroupId);
+
+                // then
+                assertThat(result).isTrue();
+
+                verify(groupRepository).findById(testMultipleMemberGroupId);
+                verify(analysisSettingRepository).countAnalysisSettingByGroupId(testMultipleMemberGroupId);
+            }
+
+            @Test
+            @DisplayName("다중 멤버 그룹에서 설정을 제출한 멤버수가 2명 미만인 경우 false를 반환해야한다.")
+            void evaluateSubmittedCondition_success_tc_04() {
+                // given
+                final long givenSubmittedCount = new Random().nextInt(2);
+                when(groupRepository.findById(testMultipleMemberGroupId)).thenReturn(Optional.of(testMultipleMemberGroup));
+                when(analysisSettingRepository.countAnalysisSettingByGroupId(testMultipleMemberGroupId)).thenReturn(givenSubmittedCount);
+
+                // when
+                final boolean result = analysisStartPolicySupport.evaluateSubmittedCondition(testMultipleMemberGroupId);
+
+                // then
+                assertThat(result).isFalse();
+
+                verify(groupRepository).findById(testMultipleMemberGroupId);
+                verify(analysisSettingRepository).countAnalysisSettingByGroupId(testMultipleMemberGroupId);
+            }
+        }
+
+        @Nested
+        @DisplayName("EXCEPTION")
+        class ExceptionTest {
+            @Test
+            @DisplayName("그룹 식별자가 null인 경우 `ConstraintViolationException` 예외가 발생해야 한다.")
+            void evaluateSubmittedCondition_exception_tc_01() {
+                // given
+                final String givenGroupId = null;
+
+                // when
+                assertThrows(ConstraintViolationException.class,
+                        () -> analysisStartPolicySupport.evaluateSubmittedCondition(givenGroupId)
+                );
+
+                verify(groupRepository, times(0)).findById(givenGroupId);
+            }
+
+            @Test
+            @DisplayName("존재하지 않는 그룹 식별자인 경우 `GroupNotFoundException`이 발생해야 한다.")
+            void evaluateSubmittedCondition_exception_tc_02() {
+                // given
+                final String givenGroupId = UUID.randomUUID().toString().replace("-", "");
+                when(groupRepository.findById(givenGroupId)).thenReturn(Optional.empty());
+
+                // when
+                assertThrows(GroupNotFoundException.class,
+                        () -> analysisStartPolicySupport.evaluateSubmittedCondition(givenGroupId)
+                );
+
+                verify(groupRepository).findById(givenGroupId);
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("evaluateAnalysisStatusCondition - 분석상태 조건")
+    class EvaluateAnalysisStatusCondition {
+
+        @Nested
+        @DisplayName("SUCCESS")
+        class SuccessTest {
+            @Test
+            @DisplayName("그룹의 분석상태가 시작전인 경우 true를 반환해야한다.")
+            void evaluateAnalysisStatusCondition_success_tc_01() {
+                // given
+                final AnalysisStatus givenAnalysisStatus = AnalysisStatus.NOT_STARTED;
+                when(groupRepository.findById(testMultipleMemberGroupId)).thenReturn(Optional.of(testMultipleMemberGroup));
+
+                Analysis mockAnalysis = mock(Analysis.class);
+                when(analysisRepository.findByGroupGroupId(testMultipleMemberGroupId)).thenReturn(Optional.of(mockAnalysis));
+                when(mockAnalysis.getAnalysisStatus()).thenReturn(givenAnalysisStatus);
+
+                // when
+                final boolean result = analysisStartPolicySupport.evaluateAnalysisStatusCondition(testMultipleMemberGroupId);
+
+                assertThat(result).isTrue();
+            }
+
+            @ParameterizedTest(name = "[CASE {index}] analysisStatus={0} -> expected=false")
+            @ValueSource(strings = {"IN_PROGRESS", "COMPLETED", "FAILED", "CANCELLED"})
+            @DisplayName("그룹의 분석상태가 시작전이 아닌 경우 false를 반환해야한다.")
+            void evaluateAnalysisStatusCondition_success_tc_02(String givenAnalysisStatusName) {
+                // given
+                AnalysisStatus givenAnalysisStatus = AnalysisStatus.valueOf(givenAnalysisStatusName);
+                when(groupRepository.findById(testMultipleMemberGroupId)).thenReturn(Optional.of(testMultipleMemberGroup));
+
+                Analysis mockAnalysis = mock(Analysis.class);
+                when(analysisRepository.findByGroupGroupId(testMultipleMemberGroupId)).thenReturn(Optional.of(mockAnalysis));
+                when(mockAnalysis.getAnalysisStatus()).thenReturn(givenAnalysisStatus);
+
+                // when
+                final boolean result = analysisStartPolicySupport.evaluateAnalysisStatusCondition(testMultipleMemberGroupId);
+
+                assertThat(result).isFalse();
+            }
+        }
+
+        @Nested
+        @DisplayName("EXCEPTION")
+        class ExceptionTest {
+
+            @Test
+            @DisplayName("존재하지 않는 그룹 식별자인 경우 `AnalysisNotFoundForGroupIdException` 예외가 발생해야 한다.")
+            void evaluateAnalysisStatusCondition_exception_tc_01() {
+                // given
+                final String givenGroupId = UUID.randomUUID().toString().replace("-", "");
+                when(analysisRepository.findByGroupGroupId(givenGroupId)).thenReturn(Optional.empty());
+
+                // when & then
+                assertThrows(AnalysisNotFoundForGroupIdException.class, () ->
+                        analysisStartPolicySupport.evaluateAnalysisStatusCondition(givenGroupId)
+                );
+
+                verify(analysisRepository).findByGroupGroupId(givenGroupId);
+            }
+
+            @Test
+            @DisplayName("그룹 식별자가 null인 경우 `ConstraintViolationException` 예외가 발생해야 한다.")
+            void evaluateAnalysisStatusCondition_exception_tc_02() {
+                // given
+                final String groupId = null;
+
+                // when & then
+                assertThrows(ConstraintViolationException.class, () ->
+                        analysisStartPolicySupport.evaluateAnalysisStatusCondition(groupId)
+                );
+            }
+        }
+    }
+}

--- a/src/test/java/com/waguwagu/weat/domain/analysis/policy/AnalysisStartPolicyTest.java
+++ b/src/test/java/com/waguwagu/weat/domain/analysis/policy/AnalysisStartPolicyTest.java
@@ -1,0 +1,206 @@
+package com.waguwagu.weat.domain.analysis.policy;
+
+import com.waguwagu.weat.domain.analysis.exception.AnalysisAlreadyStartedForGroupIdException;
+import com.waguwagu.weat.domain.analysis.exception.AnalysisConditionNotSatisfiedForGroupIdException;
+import jakarta.validation.ConstraintViolationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.validation.beanvalidation.MethodValidationPostProcessor;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {
+        AnalysisStartPolicy.class,
+        MethodValidationPostProcessor.class
+})
+class AnalysisStartPolicyTest {
+
+    @MockBean
+    AnalysisStartPolicy.AnalysisStartPolicySupport support;
+
+    @Autowired
+    AnalysisStartPolicy analysisStartPolicy;
+
+    String testGroupId;
+
+    @BeforeEach
+    void setUp() {
+        testGroupId = UUID.randomUUID().toString();
+    }
+
+    @Nested
+    @DisplayName("evaluate - 분석시작가능 조건 평가")
+    class Evaluate {
+        @Nested
+        @DisplayName("SUCCESS")
+        class SuccessTest {
+            @Test
+            @DisplayName("모든 조건이 충족된 경우 평가결과내의 모든 충족여부 값이 true로 반환되어야 한다.")
+            void evaluate_success_tc_01() {
+                // given
+                final boolean givenSubmittedCondition = true;
+                final boolean givenAnalysisStatusCondition = true;
+                final boolean expectedIsSatisfied = true;
+
+                when(support.evaluateSubmittedCondition(testGroupId)).thenReturn(givenSubmittedCondition);
+                when(support.evaluateAnalysisStatusCondition(testGroupId)).thenReturn(givenAnalysisStatusCondition);
+
+                // when
+                final AnalysisStartPolicy.Result result = analysisStartPolicy.evaluate(testGroupId);
+
+                // then
+                assertThat(result.isSubmittedConditionSatisfied()).isEqualTo(givenSubmittedCondition);
+                assertThat(result.isAnalysisStatusConditionSatisfied()).isEqualTo(givenAnalysisStatusCondition);
+                assertThat(result.isSatisfied()).isEqualTo(expectedIsSatisfied);
+            }
+
+            @ParameterizedTest(name = "[CASE{index}] givenSubmittedCondition={0}, givenAnalysisStatusCondition={1} -> expectedIsSatisfied={2}")
+            @CsvSource({
+                    "false, true,  false", // 제출조건만 불만족
+                    "true,  false, false", // 분석상태조건만 불만족
+                    "false, false, false"  // 모두 불만족
+            })
+            @DisplayName("만족하지 않는 조건이 있을 경우 불만족하는 결과에 대해서 false를 반환하고, 전체 만족여부도 false를 반환해야한다.")
+            void evaluate_success_tc_02(boolean givenSubmittedCondition, boolean givenAnalysisStatusCondition, boolean expectedIsSatisfied) {
+                // given
+                when(support.evaluateSubmittedCondition(testGroupId)).thenReturn(givenSubmittedCondition);
+                when(support.evaluateAnalysisStatusCondition(testGroupId)).thenReturn(givenAnalysisStatusCondition);
+
+                // when
+                final AnalysisStartPolicy.Result result = analysisStartPolicy.evaluate(testGroupId);
+
+                // then
+                verify(support).evaluateSubmittedCondition(testGroupId);
+                verify(support).evaluateAnalysisStatusCondition(testGroupId);
+
+                assertThat(result.isSubmittedConditionSatisfied()).isEqualTo(givenSubmittedCondition);
+                assertThat(result.isAnalysisStatusConditionSatisfied()).isEqualTo(givenAnalysisStatusCondition);
+                assertThat(result.isSatisfied()).isEqualTo(expectedIsSatisfied);
+            }
+        }
+
+        @Nested
+        @DisplayName("EXCEPTION")
+        class ExceptionTest {
+            @Test
+            @DisplayName("그룹 식별자가 null 인 경우 `ConstraintViolationException` 예외가 발생해야 한다.")
+            void evaluate_exception_tc_01() {
+                // given
+                final String givenGroupId = null;
+
+                // when & then
+                assertThrows(ConstraintViolationException.class,
+                        () -> analysisStartPolicy.evaluate(givenGroupId));
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("validate - 분석시작가능 조건 검증")
+    class Validate {
+        @Nested
+        @DisplayName("SUCCESS")
+        class SuccessTest {
+            @Test
+            @DisplayName("모든 조건을 만족한 경우에는 어떠한 예외도 발생하지 않아야 한다.")
+            void validate_success_tc_01() {
+                // given
+                final boolean givenSubmittedCondition = true;
+                final boolean givenAnalysisStatusCondition = true;
+
+                when(support.evaluateSubmittedCondition(testGroupId)).thenReturn(givenSubmittedCondition);
+                when(support.evaluateAnalysisStatusCondition(testGroupId)).thenReturn(givenAnalysisStatusCondition);
+
+                // when
+                assertDoesNotThrow(() -> analysisStartPolicy.validate(testGroupId));
+                verify(support).evaluateAnalysisStatusCondition(testGroupId);
+                verify(support).evaluateAnalysisStatusCondition(testGroupId);
+            }
+        }
+
+        @Nested
+        @DisplayName("EXCEPTION")
+        class ExceptionTest {
+            @Test
+            @DisplayName("그룹 식별자가 null 인 경우 `ConstraintViolationException` 예외가 발생해야 한다.")
+            void validate_exception_tc_01() {
+                // given
+                final String givenGroupId = null;
+
+                // when & then
+                assertThrows(
+                        ConstraintViolationException.class,
+                        () -> analysisStartPolicy.validate(givenGroupId)
+                );
+            }
+
+            @Test
+            @DisplayName("제출조건이 만족하지 않은 경우에는 `AnalysisConditionNotSatisfiedForGroupIdException`를 발생시켜야한다.")
+            void validate_exception_tc_02() {
+                // given
+                final boolean givenAnalysisStatusCondition = true;
+                final boolean givenSubmittedCondition = false;
+
+                lenient().when(support.evaluateAnalysisStatusCondition(testGroupId)).thenReturn(givenAnalysisStatusCondition);
+                lenient().when(support.evaluateSubmittedCondition(testGroupId)).thenReturn(givenSubmittedCondition);
+
+                // when & then
+                assertThrows(AnalysisConditionNotSatisfiedForGroupIdException.class,
+                        () -> analysisStartPolicy.validate(testGroupId));
+
+                verify(support).evaluateSubmittedCondition(testGroupId);
+            }
+
+            @Test
+            @DisplayName("분석상태조건이 만족하지 않은 경우에는 `AnalysisAlreadyStartedForGroupIdException`를 발생시켜야한다.")
+            void validate_exception_tc_03() {
+                // given
+                final boolean givenAnalysisStatusCondition = false;
+                final boolean givenSubmittedCondition = true;
+
+                lenient().when(support.evaluateAnalysisStatusCondition(testGroupId)).thenReturn(givenAnalysisStatusCondition);
+                lenient().when(support.evaluateSubmittedCondition(testGroupId)).thenReturn(givenSubmittedCondition);
+
+                // when & then
+                assertThrows(AnalysisAlreadyStartedForGroupIdException.class,
+                        () -> analysisStartPolicy.validate(testGroupId));
+
+                verify(support).evaluateAnalysisStatusCondition(testGroupId);
+                verify(support, never()).evaluateSubmittedCondition(testGroupId);
+            }
+
+            @Test
+            @DisplayName("모두 만족하지 않는 경우 어떠한 예외든 발생하여야 한다.")
+            void validate_exception_tc_04() {
+                // given
+                final boolean givenAnalysisStatusCondition = false;
+                final boolean givenSubmittedCondition = false;
+
+                lenient().when(support.evaluateAnalysisStatusCondition(testGroupId)).thenReturn(givenAnalysisStatusCondition);
+                lenient().when(support.evaluateSubmittedCondition(testGroupId)).thenReturn(givenSubmittedCondition);
+
+                // when & then
+                assertThrows(RuntimeException.class,
+                        () -> analysisStartPolicy.validate(testGroupId));
+
+                verify(support).evaluateAnalysisStatusCondition(testGroupId);
+                verify(support, never()).evaluateSubmittedCondition(testGroupId);
+            }
+        }
+    }
+}

--- a/src/test/java/com/waguwagu/weat/domain/analysis/repository/AnalysisSettingRepositoryImplTest.java
+++ b/src/test/java/com/waguwagu/weat/domain/analysis/repository/AnalysisSettingRepositoryImplTest.java
@@ -448,7 +448,7 @@ class AnalysisSettingRepositoryImplTest {
 
                 // then
                 assertThat(results)
-                            .isNotNull()
+                        .isNotNull()
                         .isEmpty();
             }
 
@@ -531,6 +531,122 @@ class AnalysisSettingRepositoryImplTest {
                 assertThrows(
                         NullPointerException.class,
                         () -> analysisSettingRepositoryImpl.findMemberAnalysisSettingsByGroupId(groupId)
+                );
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("countAnalysisSettingByGroupId - 그룹식별자로 그룹내에 제출된 분석 설정 개수 조회")
+    class CountAnalysisSettingByGroupId {
+        @Nested
+        @DisplayName("SUCCESS")
+        class Success {
+            @Test
+            @DisplayName("그룹내에 제출된 설정 개수와 동일한 개수가 조회되어야 한다.")
+            void countAnalysisSettingByGroupId_success_tc_01() {
+                // given
+                final Member givenMember1 = testMemberList.get(0);
+                final Member givenMember2 = testMemberList.get(1);
+                final Member givenMember3 = testMemberList.get(2);
+
+                final List<Member> givenMemberList = List.of(
+                        givenMember1, givenMember2, givenMember3
+                );
+
+                // member1 설정
+                final double givenMember1XPosition = 127.0123;
+                final double givenMember1YPosition = 37.1234;
+                final String givenMember1RoadnameAddress = "서울시 강남구 테헤란로 123";
+                final String givenMember1InputText = "맛있는 한식집을 찾고 있어요";
+
+                final Category givenMember1Category1 = testCategoryList.get(0);
+                final CategoryTag givenMember1CategoryTag1 = testCategoryTagList.get(0);
+                final boolean givenMember1IsPreferredForCategoryTag1 = true;
+
+                final Category givenMember1Category2 = testCategoryList.get(1);
+                final CategoryTag givenMember1CategoryTag2 = testCategoryTagList.get(2);
+                final boolean givenMember1IsPreferredForCategoryTag2 = false;
+
+                initMemberSettings(
+                        givenMember1,
+                        givenMember1XPosition, givenMember1YPosition,
+                        givenMember1RoadnameAddress, givenMember1InputText,
+                        List.of(
+                                new CategoryPreferredSetting(givenMember1Category1, givenMember1CategoryTag1, givenMember1IsPreferredForCategoryTag1),
+                                new CategoryPreferredSetting(givenMember1Category2, givenMember1CategoryTag2, givenMember1IsPreferredForCategoryTag2)
+                        )
+                );
+
+                // member2 설정
+                final double givenMember2XPosition = 126.9784;
+                final double givenMember2YPosition = 37.5665;
+                final String givenMember2RoadnameAddress = "서울시 종로구 세종대로 1";
+                final String givenMember2InputText = "분위기 좋은 카페를 찾고 있어요";
+                final Category givenMember2Category = testCategoryList.get(0);
+                final CategoryTag givenMember2CategoryTag = testCategoryTagList.get(1);
+                final boolean givenMember2IsPreferred = false;
+
+                initMemberSettings(
+                        givenMember2,
+                        givenMember2XPosition, givenMember2YPosition,
+                        givenMember2RoadnameAddress, givenMember2InputText,
+                        List.of(new CategoryPreferredSetting(givenMember2Category, givenMember2CategoryTag, givenMember2IsPreferred))
+                );
+
+                // member3 설정
+                final double givenMember3XPosition = 128.6014;
+                final double givenMember3YPosition = 35.8714;
+                final String givenMember3RoadnameAddress = "경기도 성남시 분당구 판교로210번길";
+                final String givenMember3InputText = "분식 맛집을 추천해주세요";
+                final Category givenMember3Category = testCategoryList.get(1);
+                final CategoryTag givenMember3CategoryTag = testCategoryTagList.get(2);
+                final boolean givenMember3IsPreferred = true;
+
+                initMemberSettings(
+                        givenMember3,
+                        givenMember3XPosition, givenMember3YPosition,
+                        givenMember3RoadnameAddress, givenMember3InputText,
+                        List.of(new CategoryPreferredSetting(givenMember3Category, givenMember3CategoryTag, givenMember3IsPreferred))
+                );
+
+                // when
+                final Long count = analysisSettingRepositoryImpl.countAnalysisSettingByGroupId(testGroup.getGroupId());
+
+                // then
+                assertThat(count).isEqualTo(givenMemberList.size());
+            }
+
+            @Test
+            @DisplayName("존재하지 않는 그룹 식별자로 조회시 0 이 조회되어야 한다.")
+            void countAnalysisSettingByGroupId_success_tc_02() {
+
+                // given
+                final String givenGroupId = "non-existent-group-id";
+
+                // when
+                final Long count = analysisSettingRepositoryImpl.countAnalysisSettingByGroupId(givenGroupId);
+
+                // then
+                assertThat(count).isEqualTo(0);
+            }
+        }
+
+        @Nested
+        @DisplayName("EXCEPTION")
+        class Exception {
+
+            @Test
+            @DisplayName("그룹 식별자가 null 인 경우 NullPointerException 이 발생하여야 한다.")
+            void countAnalysisSettingByGroupId_exception_tc_01() {
+
+                // given
+                final String givenGroupId = null;
+
+                // when & then
+                assertThrows(
+                        NullPointerException.class,
+                        () -> analysisSettingRepositoryImpl.countAnalysisSettingByGroupId(givenGroupId)
                 );
             }
         }

--- a/src/test/java/com/waguwagu/weat/domain/analysis/service/AnalysisServiceIntegrationTest.java
+++ b/src/test/java/com/waguwagu/weat/domain/analysis/service/AnalysisServiceIntegrationTest.java
@@ -1,0 +1,830 @@
+package com.waguwagu.weat.domain.analysis.service;
+
+import com.waguwagu.weat.domain.analysis.event.AnalysisStartEvent;
+import com.waguwagu.weat.domain.analysis.exception.AnalysisAlreadyStartedForGroupIdException;
+import com.waguwagu.weat.domain.analysis.exception.AnalysisConditionNotSatisfiedForGroupIdException;
+import com.waguwagu.weat.domain.analysis.exception.AnalysisNotFoundForGroupIdException;
+import com.waguwagu.weat.domain.analysis.model.dto.AIAnalysisDTO;
+import com.waguwagu.weat.domain.analysis.model.dto.AnalysisStartDTO;
+import com.waguwagu.weat.domain.analysis.model.entity.*;
+import com.waguwagu.weat.domain.analysis.repository.*;
+import com.waguwagu.weat.domain.category.model.entity.Category;
+import com.waguwagu.weat.domain.category.model.entity.CategoryTag;
+import com.waguwagu.weat.domain.category.repository.CategoryRepository;
+import com.waguwagu.weat.domain.category.repository.CategoryTagRepository;
+import com.waguwagu.weat.domain.group.exception.GroupNotFoundException;
+import com.waguwagu.weat.domain.group.model.entity.Group;
+import com.waguwagu.weat.domain.group.model.entity.Member;
+import com.waguwagu.weat.domain.group.repository.GroupRepository;
+import com.waguwagu.weat.domain.group.repository.MemberRepository;
+import com.waguwagu.weat.global.TestContainersConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import com.waguwagu.weat.domain.analysis.handler.AnalysisStartEventHandler;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.event.ApplicationEvents;
+import org.springframework.test.context.event.RecordApplicationEvents;
+import org.springframework.test.context.transaction.TestTransaction;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ActiveProfiles("test")
+@Import({TestContainersConfig.class})
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@SpringBootTest
+@RecordApplicationEvents
+@Transactional
+class AnalysisServiceIntegrationTest {
+
+    @Autowired
+    private AnalysisService analysisService;
+
+    @Autowired
+    private GroupRepository groupRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private AnalysisRepository analysisRepository;
+
+    @Autowired
+    private AnalysisSettingRepository analysisSettingRepository;
+
+    @Autowired
+    private AnalysisSettingDetailRepository analysisSettingDetailRepository;
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Autowired
+    private CategoryTagRepository categoryTagRepository;
+
+    @Autowired
+    ApplicationEvents applicationEvents;
+
+    @SpyBean
+    AnalysisStartEventHandler analysisStartEventHandler;
+
+    @SpyBean
+    AnalysisAsyncExecutor analysisAsyncExecutor;
+
+    @Autowired
+    PlatformTransactionManager platformTransactionManager;
+
+    private Group testMultiMemberGroup;
+    private Group testSingleMemberGroup;
+    private Analysis testAnalysisForMultiMemberGroup;
+    private Analysis testAnalysisForSingleMemberGroup;
+    private List<Member> testMultiMemberGroupMembers;
+    private Member testSingleMemberGroupMember;
+    private List<Category> testCategories;
+    private List<CategoryTag> testCategoryTags;
+
+    @BeforeEach
+    void setUp() {
+        testMultiMemberGroup = groupRepository.save(Group.builder()
+                .isSingleMemberGroup(false)
+                .build());
+
+        testSingleMemberGroup = groupRepository.save(Group.builder()
+                .isSingleMemberGroup(true)
+                .build());
+
+        testMultiMemberGroupMembers = List.of(
+                memberRepository.save(Member.builder()
+                        .group(testMultiMemberGroup)
+                        .isGroupOwner(true)
+                        .build()),
+                memberRepository.save(Member.builder()
+                        .group(testMultiMemberGroup)
+                        .isGroupOwner(false)
+                        .build()),
+                memberRepository.save(Member.builder()
+                        .group(testMultiMemberGroup)
+                        .isGroupOwner(false)
+                        .build())
+        );
+
+        testSingleMemberGroupMember = memberRepository.save(Member.builder()
+                .group(testSingleMemberGroup)
+                .isGroupOwner(true)
+                .build());
+
+        testAnalysisForMultiMemberGroup = analysisRepository.save(Analysis.builder()
+                .group(testMultiMemberGroup)
+                .analysisStatus(AnalysisStatus.NOT_STARTED)
+                .build());
+
+        testAnalysisForSingleMemberGroup = analysisRepository.save(Analysis.builder()
+                .group(testSingleMemberGroup)
+                .analysisStatus(AnalysisStatus.NOT_STARTED)
+                .build());
+
+        testCategories = List.of(
+                categoryRepository.save(Category.builder()
+                        .categoryName("한식")
+                        .categoryOrder(1L)
+                        .build()),
+                categoryRepository.save(Category.builder()
+                        .categoryName("일식")
+                        .categoryOrder(2L)
+                        .build()),
+                categoryRepository.save(Category.builder()
+                        .categoryName("양식")
+                        .categoryOrder(3L)
+                        .build())
+        );
+
+        testCategoryTags = List.of(
+                categoryTagRepository.save(CategoryTag.builder()
+                        .category(testCategories.get(0))
+                        .categoryTagName("백반")
+                        .categoryTagOrder(1L)
+                        .categoryTagVersion("v2")
+                        .build()),
+                categoryTagRepository.save(CategoryTag.builder()
+                        .category(testCategories.get(0))
+                        .categoryTagName("삼겹살")
+                        .categoryTagOrder(2L)
+                        .categoryTagVersion("v2")
+                        .build()),
+                categoryTagRepository.save(CategoryTag.builder()
+                        .category(testCategories.get(1))
+                        .categoryTagName("스시")
+                        .categoryTagOrder(3L)
+                        .categoryTagVersion("v2")
+                        .build())
+        );
+    }
+
+    private void createMemberAnalysisSetting(
+            Member member,
+            Analysis analysis,
+            Double xPosition,
+            Double yPosition,
+            String roadnameAddress,
+            String inputText,
+            List<CategoryPreferredSetting> categorySettings
+    ) {
+        AnalysisSetting analysisSetting = analysisSettingRepository.save(
+                AnalysisSetting.builder()
+                        .analysis(analysis)
+                        .member(member)
+                        .build());
+
+        analysisSettingDetailRepository.save(LocationSetting.builder()
+                .analysisSetting(analysisSetting)
+                .xPosition(xPosition)
+                .yPosition(yPosition)
+                .roadnameAddress(roadnameAddress)
+                .build());
+
+        if (inputText != null) {
+            analysisSettingDetailRepository.save(TextInputSetting.builder()
+                    .analysisSetting(analysisSetting)
+                    .inputText(inputText)
+                    .build());
+        }
+
+        for (CategoryPreferredSetting categorySetting : categorySettings) {
+            analysisSettingDetailRepository.save(CategorySetting.builder()
+                    .analysisSetting(analysisSetting)
+                    .category(categorySetting.category())
+                    .categoryTag(categorySetting.categoryTag())
+                    .isPreferred(categorySetting.isPreferred())
+                    .build());
+        }
+    }
+
+    private record CategoryPreferredSetting(
+            Category category,
+            CategoryTag categoryTag,
+            boolean isPreferred
+    ) {
+    }
+
+    @Nested
+    @DisplayName("analysisStart - 분석시작")
+    class AnalysisStart {
+
+        @Nested
+        @DisplayName("SUCCESS")
+        class SuccessTest {
+
+            @Test
+            @DisplayName("다중 멤버 그룹에서 2명 이상의 설정이 제출된 경우 분석이 시작되어야 한다.")
+            void analysisStart_success_tc_01() {
+                // given
+                final Member givenMember1 = testMultiMemberGroupMembers.get(0);
+                final Member givenMember2 = testMultiMemberGroupMembers.get(1);
+
+                final double givenMember1XPosition = 127.0123;
+                final double givenMember1YPosition = 37.1234;
+                final String givenMember1RoadnameAddress = "서울시 강남구 테헤란로 123";
+                final String givenMember1InputText = "맛있는 한식집을 찾고 있어요";
+
+                final double givenMember2XPosition = 126.9784;
+                final double givenMember2YPosition = 37.5665;
+                final String givenMember2RoadnameAddress = "서울시 종로구 세종대로 1";
+                final String givenMember2InputText = "분위기 좋은 카페를 찾고 있어요";
+
+                createMemberAnalysisSetting(
+                        givenMember1,
+                        testAnalysisForMultiMemberGroup,
+                        givenMember1XPosition,
+                        givenMember1YPosition,
+                        givenMember1RoadnameAddress,
+                        givenMember1InputText,
+                        List.of(
+                                new CategoryPreferredSetting(testCategories.get(0), testCategoryTags.get(0), true),
+                                new CategoryPreferredSetting(testCategories.get(1), testCategoryTags.get(2), false)
+                        )
+                );
+
+                createMemberAnalysisSetting(
+                        givenMember2,
+                        testAnalysisForMultiMemberGroup,
+                        givenMember2XPosition,
+                        givenMember2YPosition,
+                        givenMember2RoadnameAddress,
+                        givenMember2InputText,
+                        List.of(
+                                new CategoryPreferredSetting(testCategories.get(0), testCategoryTags.get(1), false)
+                        )
+                );
+
+                final AnalysisStartDTO.Request givenRequest = AnalysisStartDTO.Request.builder()
+                        .groupId(testMultiMemberGroup.getGroupId())
+                        .build();
+
+                // when
+                final AnalysisStartDTO.Response response = analysisService.analysisStart(givenRequest);
+
+                // then
+                assertThat(response.getGroupId()).isEqualTo(testMultiMemberGroup.getGroupId());
+                assertThat(response.getAnalysisId()).isEqualTo(testAnalysisForMultiMemberGroup.getAnalysisId());
+                assertThat(response.getAnalysisStatus()).isEqualTo(AnalysisStatus.IN_PROGRESS.toString());
+
+                final Analysis savedAnalysis = analysisRepository.findById(testAnalysisForMultiMemberGroup.getAnalysisId())
+                        .orElseThrow();
+                assertThat(savedAnalysis.getAnalysisStatus()).isEqualTo(AnalysisStatus.IN_PROGRESS);
+
+                final List<AnalysisStartEvent> events = applicationEvents.stream(AnalysisStartEvent.class).toList();
+                assertThat(events).hasSize(1);
+
+                final AnalysisStartEvent event = events.get(0);
+                assertThat(event.groupId()).isEqualTo(testMultiMemberGroup.getGroupId());
+                assertThat(event.analysisId()).isEqualTo(testAnalysisForMultiMemberGroup.getAnalysisId());
+                assertThat(event.memberSettingList()).hasSize(2);
+            }
+
+            @Test
+            @DisplayName("단일 멤버 그룹에서 1명의 설정이 제출된 경우 분석이 시작되어야 한다.")
+            void analysisStart_success_tc_02() {
+                // given
+                final double givenMember1XPosition = 127.0123;
+                final double givenMember1YPosition = 37.1234;
+                final String givenMember1RoadnameAddress = "서울시 강남구 테헤란로 123";
+                final String givenMember1InputText = "맛있는 한식집을 찾고 있어요";
+
+                createMemberAnalysisSetting(
+                        testSingleMemberGroupMember,
+                        testAnalysisForSingleMemberGroup,
+                        givenMember1XPosition,
+                        givenMember1YPosition,
+                        givenMember1RoadnameAddress,
+                        givenMember1InputText,
+                        List.of(
+                                new CategoryPreferredSetting(testCategories.get(0), testCategoryTags.get(0), true)
+                        )
+                );
+
+                final AnalysisStartDTO.Request givenRequest = AnalysisStartDTO.Request.builder()
+                        .groupId(testSingleMemberGroup.getGroupId())
+                        .build();
+
+                // when
+                final AnalysisStartDTO.Response response = analysisService.analysisStart(givenRequest);
+
+                // then
+                assertThat(response.getGroupId()).isEqualTo(testSingleMemberGroup.getGroupId());
+                assertThat(response.getAnalysisId()).isEqualTo(testAnalysisForSingleMemberGroup.getAnalysisId());
+                assertThat(response.getAnalysisStatus()).isEqualTo(AnalysisStatus.IN_PROGRESS.toString());
+
+                final Analysis savedAnalysis = analysisRepository.findById(testAnalysisForSingleMemberGroup.getAnalysisId())
+                        .orElseThrow();
+                assertThat(savedAnalysis.getAnalysisStatus()).isEqualTo(AnalysisStatus.IN_PROGRESS);
+
+                final List<AnalysisStartEvent> events = applicationEvents.stream(AnalysisStartEvent.class).toList();
+                assertThat(events).hasSize(1);
+
+                final AnalysisStartEvent event = events.get(0);
+                assertThat(event.groupId()).isEqualTo(testSingleMemberGroup.getGroupId());
+                assertThat(event.analysisId()).isEqualTo(testAnalysisForSingleMemberGroup.getAnalysisId());
+                assertThat(event.memberSettingList()).hasSize(1);
+            }
+
+            @Test
+            @DisplayName("분석시작 후 이벤트에 포함된 멤버 설정 정보가 실제 제출된 설정과 일치해야 한다.")
+            void analysisStart_success_tc_03() {
+                // given
+                final Member givenMember1 = testMultiMemberGroupMembers.get(0);
+                final Member givenMember2 = testMultiMemberGroupMembers.get(1);
+
+                final double givenMember1XPosition = 127.0123;
+                final double givenMember1YPosition = 37.1234;
+                final String givenMember1RoadnameAddress = "서울시 강남구 테헤란로 123";
+                final String givenMember1InputText = "맛있는 한식집을 찾고 있어요";
+
+                final double givenMember2XPosition = 126.9784;
+                final double givenMember2YPosition = 37.5665;
+                final String givenMember2RoadnameAddress = "서울시 종로구 세종대로 1";
+                final String givenMember2InputText = "분위기 좋은 카페를 찾고 있어요";
+
+                createMemberAnalysisSetting(
+                        givenMember1,
+                        testAnalysisForMultiMemberGroup,
+                        givenMember1XPosition,
+                        givenMember1YPosition,
+                        givenMember1RoadnameAddress,
+                        givenMember1InputText,
+                        List.of(
+                                new CategoryPreferredSetting(testCategories.get(0), testCategoryTags.get(0), true),
+                                new CategoryPreferredSetting(testCategories.get(1), testCategoryTags.get(2), false)
+                        )
+                );
+
+                createMemberAnalysisSetting(
+                        givenMember2,
+                        testAnalysisForMultiMemberGroup,
+                        givenMember2XPosition,
+                        givenMember2YPosition,
+                        givenMember2RoadnameAddress,
+                        givenMember2InputText,
+                        List.of(
+                                new CategoryPreferredSetting(testCategories.get(0), testCategoryTags.get(1), false)
+                        )
+                );
+
+                final AnalysisStartDTO.Request givenRequest = AnalysisStartDTO.Request.builder()
+                        .groupId(testMultiMemberGroup.getGroupId())
+                        .build();
+
+                // when
+                analysisService.analysisStart(givenRequest);
+
+                // then
+                final AnalysisStartEvent event = applicationEvents.stream(AnalysisStartEvent.class)
+                        .findFirst()
+                        .orElseThrow();
+
+                assertThat(event.memberSettingList()).hasSize(2);
+
+                final AIAnalysisDTO.Request.MemberSetting member1Setting = event.memberSettingList().stream()
+                        .filter(ms -> ms.getMemberId().equals(givenMember1.getMemberId()))
+                        .findFirst()
+                        .orElseThrow();
+
+                assertThat(member1Setting.getMemberId()).isEqualTo(givenMember1.getMemberId());
+                assertThat(member1Setting.getXPosition()).isEqualTo(givenMember1XPosition);
+                assertThat(member1Setting.getYPosition()).isEqualTo(givenMember1YPosition);
+                assertThat(member1Setting.getRoadnameAddress()).isEqualTo(givenMember1RoadnameAddress);
+                assertThat(member1Setting.getInputText()).isEqualTo(givenMember1InputText);
+                assertThat(member1Setting.getCategoryList()).hasSize(2);
+
+                final AIAnalysisDTO.Request.MemberSetting member2Setting = event.memberSettingList().stream()
+                        .filter(ms -> ms.getMemberId().equals(givenMember2.getMemberId()))
+                        .findFirst()
+                        .orElseThrow();
+
+                assertThat(member2Setting.getMemberId()).isEqualTo(givenMember2.getMemberId());
+                assertThat(member2Setting.getXPosition()).isEqualTo(givenMember2XPosition);
+                assertThat(member2Setting.getYPosition()).isEqualTo(givenMember2YPosition);
+                assertThat(member2Setting.getRoadnameAddress()).isEqualTo(givenMember2RoadnameAddress);
+                assertThat(member2Setting.getInputText()).isEqualTo(givenMember2InputText);
+                assertThat(member2Setting.getCategoryList()).hasSize(1);
+            }
+
+            @Test
+            @DisplayName("텍스트 입력 설정이 없는 멤버의 설정도 이벤트에 포함되어야 한다.")
+            void analysisStart_success_tc_04() {
+                // given
+                final Member givenMember1 = testMultiMemberGroupMembers.get(0);
+                final Member givenMember2 = testMultiMemberGroupMembers.get(1);
+
+                final double givenMember1XPosition = 127.0123;
+                final double givenMember1YPosition = 37.1234;
+                final String givenMember1RoadnameAddress = "서울시 강남구 테헤란로 123";
+                final String givenMember1InputText = "맛있는 한식집을 찾고 있어요";
+
+                final double givenMember2XPosition = 126.9784;
+                final double givenMember2YPosition = 37.5665;
+                final String givenMember2RoadnameAddress = "서울시 종로구 세종대로 1";
+                final String givenMember2InputText = null;
+
+                createMemberAnalysisSetting(
+                        givenMember1,
+                        testAnalysisForMultiMemberGroup,
+                        givenMember1XPosition,
+                        givenMember1YPosition,
+                        givenMember1RoadnameAddress,
+                        givenMember1InputText,
+                        List.of(
+                                new CategoryPreferredSetting(testCategories.get(0), testCategoryTags.get(0), true)
+                        )
+                );
+
+                createMemberAnalysisSetting(
+                        givenMember2,
+                        testAnalysisForMultiMemberGroup,
+                        givenMember2XPosition,
+                        givenMember2YPosition,
+                        givenMember2RoadnameAddress,
+                        givenMember2InputText,
+                        List.of(
+                                new CategoryPreferredSetting(testCategories.get(0), testCategoryTags.get(1), false)
+                        )
+                );
+
+                final AnalysisStartDTO.Request givenRequest = AnalysisStartDTO.Request.builder()
+                        .groupId(testMultiMemberGroup.getGroupId())
+                        .build();
+
+                // when
+                analysisService.analysisStart(givenRequest);
+
+                // then
+                final AnalysisStartEvent event = applicationEvents.stream(AnalysisStartEvent.class)
+                        .findFirst()
+                        .orElseThrow();
+
+                assertThat(event.memberSettingList()).hasSize(2);
+
+                final AIAnalysisDTO.Request.MemberSetting member2Setting = event.memberSettingList().stream()
+                        .filter(ms -> ms.getMemberId().equals(givenMember2.getMemberId()))
+                        .findFirst()
+                        .orElseThrow();
+
+                assertThat(member2Setting.getInputText()).isNull();
+            }
+
+            @Test
+            @DisplayName("분석시작이 정상적으로 완료되면 데이터베이스에 분석 상태가 저장되고 핸들러가 실행되어야 한다.")
+            void analysisStart_success_tc_05() {
+                // given
+                final Member givenMember1 = testMultiMemberGroupMembers.get(0);
+                final Member givenMember2 = testMultiMemberGroupMembers.get(1);
+
+                final double givenMember1XPosition = 127.0123;
+                final double givenMember1YPosition = 37.1234;
+                final String givenMember1RoadnameAddress = "서울시 강남구 테헤란로 123";
+                final String givenMember1InputText = "맛있는 한식집을 찾고 있어요";
+
+                final double givenMember2XPosition = 126.9784;
+                final double givenMember2YPosition = 37.5665;
+                final String givenMember2RoadnameAddress = "서울시 종로구 세종대로 1";
+                final String givenMember2InputText = "분위기 좋은 카페를 찾고 있어요";
+
+                createMemberAnalysisSetting(
+                        givenMember1,
+                        testAnalysisForMultiMemberGroup,
+                        givenMember1XPosition,
+                        givenMember1YPosition,
+                        givenMember1RoadnameAddress,
+                        givenMember1InputText,
+                        List.of(
+                                new CategoryPreferredSetting(testCategories.get(0), testCategoryTags.get(0), true)
+                        )
+                );
+
+                createMemberAnalysisSetting(
+                        givenMember2,
+                        testAnalysisForMultiMemberGroup,
+                        givenMember2XPosition,
+                        givenMember2YPosition,
+                        givenMember2RoadnameAddress,
+                        givenMember2InputText,
+                        List.of(
+                                new CategoryPreferredSetting(testCategories.get(0), testCategoryTags.get(1), false)
+                        )
+                );
+
+                final AnalysisStartDTO.Request givenRequest = AnalysisStartDTO.Request.builder()
+                        .groupId(testMultiMemberGroup.getGroupId())
+                        .build();
+
+                doNothing().when(analysisAsyncExecutor)
+                        .startAnalysisAsync(any(AIAnalysisDTO.Request.class));
+
+                // when
+                TestTransaction.flagForCommit();
+                TestTransaction.end();
+
+                TestTransaction.start();
+                analysisService.analysisStart(givenRequest);
+                TestTransaction.flagForCommit();
+                TestTransaction.end();
+
+                // then
+                final Analysis savedAnalysis = analysisRepository.findById(testAnalysisForMultiMemberGroup.getAnalysisId())
+                        .orElseThrow();
+                assertThat(savedAnalysis.getAnalysisStatus()).isEqualTo(AnalysisStatus.IN_PROGRESS);
+
+                final List<AnalysisStartEvent> events = applicationEvents.stream(AnalysisStartEvent.class).toList();
+                assertThat(events).hasSize(1);
+
+                verify(analysisAsyncExecutor, timeout(3000))
+                        .startAnalysisAsync(any(AIAnalysisDTO.Request.class));
+            }
+
+            @Test
+            @DisplayName("분석시작이 정상적으로 완료되어 트랜잭션이 커밋되면 이벤트 핸들러가 실행되어 AI 분석요청이 시작되어야 한다.")
+            void analysisStart_success_tc_06() {
+                // given
+                final Member givenMember1 = testMultiMemberGroupMembers.get(0);
+                final Member givenMember2 = testMultiMemberGroupMembers.get(1);
+
+                final double givenMember1XPosition = 127.0123;
+                final double givenMember1YPosition = 37.1234;
+                final String givenMember1RoadnameAddress = "서울시 강남구 테헤란로 123";
+                final String givenMember1InputText = "맛있는 한식집을 찾고 있어요";
+
+                final double givenMember2XPosition = 126.9784;
+                final double givenMember2YPosition = 37.5665;
+                final String givenMember2RoadnameAddress = "서울시 종로구 세종대로 1";
+                final String givenMember2InputText = "분위기 좋은 카페를 찾고 있어요";
+
+                createMemberAnalysisSetting(
+                        givenMember1,
+                        testAnalysisForMultiMemberGroup,
+                        givenMember1XPosition,
+                        givenMember1YPosition,
+                        givenMember1RoadnameAddress,
+                        givenMember1InputText,
+                        List.of(
+                                new CategoryPreferredSetting(testCategories.get(0), testCategoryTags.get(0), true),
+                                new CategoryPreferredSetting(testCategories.get(1), testCategoryTags.get(2), false)
+                        )
+                );
+
+                createMemberAnalysisSetting(
+                        givenMember2,
+                        testAnalysisForMultiMemberGroup,
+                        givenMember2XPosition,
+                        givenMember2YPosition,
+                        givenMember2RoadnameAddress,
+                        givenMember2InputText,
+                        List.of(
+                                new CategoryPreferredSetting(testCategories.get(0), testCategoryTags.get(1), false)
+                        )
+                );
+
+                doNothing().when(analysisAsyncExecutor)
+                        .startAnalysisAsync(any(AIAnalysisDTO.Request.class));
+
+                final AnalysisStartDTO.Request givenRequest = AnalysisStartDTO.Request.builder()
+                        .groupId(testMultiMemberGroup.getGroupId())
+                        .build();
+
+                // when
+                TestTransaction.flagForCommit();
+                TestTransaction.end();
+
+                TestTransaction.start();
+                analysisService.analysisStart(givenRequest);
+                TestTransaction.flagForCommit();
+                TestTransaction.end();
+
+                // then
+                final List<AnalysisStartEvent> events = applicationEvents.stream(AnalysisStartEvent.class).toList();
+                assertThat(events).hasSize(1);
+
+                final AnalysisStartEvent event = events.get(0);
+                assertThat(event.groupId()).isEqualTo(testMultiMemberGroup.getGroupId());
+                assertThat(event.analysisId()).isEqualTo(testAnalysisForMultiMemberGroup.getAnalysisId());
+
+                final ArgumentCaptor<AIAnalysisDTO.Request> requestCaptor =
+                        ArgumentCaptor.forClass(AIAnalysisDTO.Request.class);
+                verify(analysisAsyncExecutor, timeout(3000))
+                        .startAnalysisAsync(requestCaptor.capture());
+
+                final AIAnalysisDTO.Request aiAnalysisRequest = requestCaptor.getValue();
+                assertThat(aiAnalysisRequest.getGroupId()).isEqualTo(testMultiMemberGroup.getGroupId());
+                assertThat(aiAnalysisRequest.getAnalysisId()).isEqualTo(testAnalysisForMultiMemberGroup.getAnalysisId());
+                assertThat(aiAnalysisRequest.getMemberSettingList()).hasSize(2);
+            }
+        }
+
+        @Nested
+        @DisplayName("EXCEPTION")
+        class ExceptionTest {
+
+            @Test
+            @DisplayName("존재하지 않는 그룹 식별자인 경우 `GroupNotFoundException` 예외가 발생해야 한다.")
+            void analysisStart_exception_tc_01() {
+                // given
+                final String givenNonExistentGroupId = UUID.randomUUID().toString().replace("-", "");
+                final AnalysisStartDTO.Request givenRequest = AnalysisStartDTO.Request.builder()
+                        .groupId(givenNonExistentGroupId)
+                        .build();
+
+                // when & then
+                assertThrows(GroupNotFoundException.class, () ->
+                        analysisService.analysisStart(givenRequest)
+                );
+            }
+
+            @Test
+            @DisplayName("그룹에 대한 분석정보가 사전에 생성되어 있지 않은 경우 `AnalysisNotFoundForGroupIdException` 예외가 발생하여야 한다.")
+            void analysisStart_exception_tc_02() {
+                // given
+                final Group givenGroupWithoutAnalysis = groupRepository.save(Group.builder()
+                        .isSingleMemberGroup(false)
+                        .build());
+
+                final AnalysisStartDTO.Request givenRequest = AnalysisStartDTO.Request.builder()
+                        .groupId(givenGroupWithoutAnalysis.getGroupId())
+                        .build();
+
+                // when & then
+                assertThrows(AnalysisNotFoundForGroupIdException.class, () ->
+                        analysisService.analysisStart(givenRequest)
+                );
+            }
+
+            @Test
+            @DisplayName("이미 분석이 시작된 그룹인 경우 `AnalysisAlreadyStartedForGroupIdException` 예외가 발생해야 한다.")
+            void analysisStart_exception_tc_03() {
+                // given
+                final Member givenMember1 = testMultiMemberGroupMembers.get(0);
+                final Member givenMember2 = testMultiMemberGroupMembers.get(1);
+
+                final double givenMember1XPosition = 127.0123;
+                final double givenMember1YPosition = 37.1234;
+                final String givenMember1RoadnameAddress = "서울시 강남구 테헤란로 123";
+                final String givenMember1InputText = "맛있는 한식집을 찾고 있어요";
+
+                final double givenMember2XPosition = 126.9784;
+                final double givenMember2YPosition = 37.5665;
+                final String givenMember2RoadnameAddress = "서울시 종로구 세종대로 1";
+                final String givenMember2InputText = "분위기 좋은 카페를 찾고 있어요";
+
+                createMemberAnalysisSetting(
+                        givenMember1,
+                        testAnalysisForMultiMemberGroup,
+                        givenMember1XPosition,
+                        givenMember1YPosition,
+                        givenMember1RoadnameAddress,
+                        givenMember1InputText,
+                        List.of(
+                                new CategoryPreferredSetting(testCategories.get(0), testCategoryTags.get(0), true)
+                        )
+                );
+
+                createMemberAnalysisSetting(
+                        givenMember2,
+                        testAnalysisForMultiMemberGroup,
+                        givenMember2XPosition,
+                        givenMember2YPosition,
+                        givenMember2RoadnameAddress,
+                        givenMember2InputText,
+                        List.of(
+                                new CategoryPreferredSetting(testCategories.get(0), testCategoryTags.get(1), false)
+                        )
+                );
+
+                final AnalysisStartDTO.Request givenFirstRequest = AnalysisStartDTO.Request.builder()
+                        .groupId(testMultiMemberGroup.getGroupId())
+                        .build();
+                analysisService.analysisStart(givenFirstRequest);
+
+                final Analysis analysis = analysisRepository.findByGroupGroupId(testMultiMemberGroup.getGroupId())
+                        .orElseThrow();
+                analysis.setAnalysisStatus(AnalysisStatus.IN_PROGRESS);
+                analysisRepository.save(analysis);
+
+                // when & then
+                final AnalysisStartDTO.Request givenSecondRequest = AnalysisStartDTO.Request.builder()
+                        .groupId(testMultiMemberGroup.getGroupId())
+                        .build();
+
+                assertThrows(AnalysisAlreadyStartedForGroupIdException.class, () ->
+                        analysisService.analysisStart(givenSecondRequest)
+                );
+            }
+
+            @Test
+            @DisplayName("다중 멤버 그룹에서 설정 제출 조건을 만족하지 못한 경우 `AnalysisConditionNotSatisfiedForGroupIdException` 예외가 발생해야 한다.")
+            void analysisStart_exception_tc_04() {
+                // given
+                final Member givenMember1 = testMultiMemberGroupMembers.get(0);
+
+                final double givenMember1XPosition = 127.0123;
+                final double givenMember1YPosition = 37.1234;
+                final String givenMember1RoadnameAddress = "서울시 강남구 테헤란로 123";
+                final String givenMember1InputText = "맛있는 한식집을 찾고 있어요";
+
+                createMemberAnalysisSetting(
+                        givenMember1,
+                        testAnalysisForMultiMemberGroup,
+                        givenMember1XPosition,
+                        givenMember1YPosition,
+                        givenMember1RoadnameAddress,
+                        givenMember1InputText,
+                        List.of(
+                                new CategoryPreferredSetting(testCategories.get(0), testCategoryTags.get(0), true)
+                        )
+                );
+
+                final AnalysisStartDTO.Request givenRequest = AnalysisStartDTO.Request.builder()
+                        .groupId(testMultiMemberGroup.getGroupId())
+                        .build();
+
+                // when & then
+                assertThrows(AnalysisConditionNotSatisfiedForGroupIdException.class, () ->
+                        analysisService.analysisStart(givenRequest)
+                );
+            }
+
+            @Test
+            @DisplayName("단일 멤버 그룹에서 설정이 제출되지 않은 경우 `AnalysisConditionNotSatisfiedForGroupIdException` 예외가 발생해야 한다.")
+            void analysisStart_exception_tc_05() {
+                // given
+                final AnalysisStartDTO.Request givenRequest = AnalysisStartDTO.Request.builder()
+                        .groupId(testSingleMemberGroup.getGroupId())
+                        .build();
+
+                // when & then
+                assertThrows(AnalysisConditionNotSatisfiedForGroupIdException.class, () ->
+                        analysisService.analysisStart(givenRequest)
+                );
+            }
+
+            @Test
+            @DisplayName("트랜잭션 롤백 시 분석시작 이벤트는 발행되지 않아야하며 이벤트 핸들러와 AI 분석요청이 실행되지 않아야 한다.")
+            void analysisStart_exception_tc_06() throws InterruptedException {
+                // given
+                final Member givenMember1 = testMultiMemberGroupMembers.get(0);
+
+                final double givenMember1XPosition = 127.0123;
+                final double givenMember1YPosition = 37.1234;
+                final String givenMember1RoadnameAddress = "서울시 강남구 테헤란로 123";
+                final String givenMember1InputText = "맛있는 한식집을 찾고 있어요";
+
+                createMemberAnalysisSetting(
+                        givenMember1,
+                        testAnalysisForMultiMemberGroup,
+                        givenMember1XPosition,
+                        givenMember1YPosition,
+                        givenMember1RoadnameAddress,
+                        givenMember1InputText,
+                        List.of(
+                                new CategoryPreferredSetting(testCategories.get(0), testCategoryTags.get(0), true)
+                        )
+                );
+
+                final AnalysisStartDTO.Request givenRequest = AnalysisStartDTO.Request.builder()
+                        .groupId(testMultiMemberGroup.getGroupId())
+                        .build();
+
+                // when
+                assertThrows(AnalysisConditionNotSatisfiedForGroupIdException.class, () ->
+                        analysisService.analysisStart(givenRequest)
+                );
+
+                Thread.sleep(100);
+
+                // then
+                final List<AnalysisStartEvent> events = applicationEvents.stream(AnalysisStartEvent.class).toList();
+                assertThat(events).isEmpty();
+
+                verify(analysisStartEventHandler, never())
+                        .handleAnalysisStartEvent(any(AnalysisStartEvent.class));
+
+                verify(analysisAsyncExecutor, never())
+                        .startAnalysisAsync(any(AIAnalysisDTO.Request.class));
+
+                final Analysis savedAnalysis = analysisRepository.findById(testAnalysisForMultiMemberGroup.getAnalysisId())
+                        .orElseThrow();
+                assertThat(savedAnalysis.getAnalysisStatus()).isEqualTo(AnalysisStatus.NOT_STARTED);
+            }
+        }
+    }
+}

--- a/src/test/java/com/waguwagu/weat/domain/analysis/service/AnalysisServiceTest.java
+++ b/src/test/java/com/waguwagu/weat/domain/analysis/service/AnalysisServiceTest.java
@@ -1,8 +1,14 @@
 package com.waguwagu.weat.domain.analysis.service;
 
 import com.waguwagu.weat.domain.analysis.adaptor.AIServiceAdaptor;
+import com.waguwagu.weat.domain.analysis.event.AnalysisStartEvent;
+import com.waguwagu.weat.domain.analysis.exception.AnalysisAlreadyStartedForGroupIdException;
+import com.waguwagu.weat.domain.analysis.exception.AnalysisConditionNotSatisfiedForGroupIdException;
 import com.waguwagu.weat.domain.analysis.exception.AnalysisNotFoundForGroupIdException;
+import com.waguwagu.weat.domain.analysis.model.dto.AIAnalysisDTO;
+import com.waguwagu.weat.domain.analysis.model.dto.AnalysisStartDTO;
 import com.waguwagu.weat.domain.analysis.model.dto.GetAnalysisStatusDTO;
+import com.waguwagu.weat.domain.analysis.model.dto.MemberAnalysisSettingDTO;
 import com.waguwagu.weat.domain.analysis.model.entity.Analysis;
 import com.waguwagu.weat.domain.analysis.model.entity.AnalysisStatus;
 import com.waguwagu.weat.domain.analysis.policy.AnalysisSettingSubmitPolicy;
@@ -19,21 +25,24 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.event.ApplicationEvents;
+import org.springframework.test.context.event.RecordApplicationEvents;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.validation.beanvalidation.MethodValidationPostProcessor;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
+@RecordApplicationEvents
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = {
         AnalysisService.class,
@@ -59,8 +68,8 @@ class AnalysisServiceTest {
     AnalysisResultLikeRepository analysisResultLikeRepository;
     @MockBean
     AnalysisResultDetailRepository analysisResultDetailRepository;
-    @MockBean
-    ApplicationEventPublisher eventPublisher;
+    @Autowired
+    ApplicationEvents applicationEvents;
     @MockBean
     AnalysisStartPolicy analysisStartPolicy;
     @MockBean
@@ -170,6 +179,263 @@ class AnalysisServiceTest {
                         analysisService.getAnalysisStatus(givenGroupId)
                 );
             }
+        }
+    }
+
+    @Nested
+    @DisplayName("analysisStart - 분석시작")
+    class AnalysisStart {
+
+        String givenGroupId;
+        Group givenGroup;
+        Analysis givenAnalysis;
+        List<MemberAnalysisSettingDTO> givenMemberAnalysisSettings;
+        AnalysisStartDTO.Request givenRequest;
+
+        @BeforeEach
+        void setUp() {
+            givenGroupId = UUID.randomUUID().toString().replace("-", "");
+            givenGroup = Group.builder()
+                    .groupId(givenGroupId)
+                    .isSingleMemberGroup(false)
+                    .build();
+
+            givenAnalysis = Analysis.builder()
+                    .analysisId(0L)
+                    .group(givenGroup)
+                    .analysisStatus(AnalysisStatus.NOT_STARTED)
+                    .build();
+
+            givenRequest = AnalysisStartDTO.Request.builder()
+                    .groupId(givenGroupId)
+                    .build();
+
+            final MemberAnalysisSettingDTO memberSettingDto1 = buildMemberAnalysisSettingDto(
+                    1L, 127.123456, 37.987654,
+                    "경기도 성남시 수정구 창업로 42", "주변 맛집 추천",
+                    List.of(
+                            buildCategorySettingDto(0L, "한식", 10L, "백반", true),
+                            buildCategorySettingDto(1L, "중식", 11L, "짜장면", false),
+                            buildCategorySettingDto(3L, "카페", 21L, "디저트", true)
+                    )
+            );
+            final MemberAnalysisSettingDTO memberSettingDto2 = buildMemberAnalysisSettingDto(
+                    2L, 127.223456, 37.887654,
+                    "서울특별시 중구 을지로 12", "회사 근처 점심 추천",
+                    List.of(
+                            buildCategorySettingDto(0L, "한식", 12L, "된장찌개", false),
+                            buildCategorySettingDto(2L, "일식", 13L, "스시", true),
+                            buildCategorySettingDto(4L, "양식", 14L, "파스타", true),
+                            buildCategorySettingDto(5L, "분식", 15L, "떡볶이", false)
+                    )
+            );
+            givenMemberAnalysisSettings = List.of(memberSettingDto1, memberSettingDto2);
+
+            when(groupRepository.findById(givenGroupId)).thenReturn(Optional.of(givenGroup));
+            doNothing().when(analysisStartPolicy).validate(givenGroupId);
+            when(analysisRepository.findByGroupGroupId(givenGroupId)).thenReturn(Optional.of(givenAnalysis));
+            when(analysisSettingRepository.findMemberAnalysisSettingsByGroupId(givenGroupId))
+                    .thenReturn(givenMemberAnalysisSettings);
+        }
+
+        @Nested
+        @DisplayName("SUCCESS")
+        class SuccessTest {
+            @Test
+            @DisplayName("분석시작 내부 처리과정이 올바른 순서로 진행되어야 한다.")
+            void analysisStart_success_tc_01() {
+                // when
+                analysisService.analysisStart(givenRequest);
+
+                // then
+                InOrder inOrder = inOrder(groupRepository, analysisStartPolicy, analysisRepository, analysisSettingRepository);
+                inOrder.verify(groupRepository).findById(givenGroupId);
+                inOrder.verify(analysisStartPolicy).validate(givenGroupId);
+                inOrder.verify(analysisRepository).findByGroupGroupId(givenGroupId);
+                inOrder.verify(analysisSettingRepository).findMemberAnalysisSettingsByGroupId(givenGroupId);
+                verifyNoMoreInteractions(groupRepository, analysisStartPolicy, analysisRepository, analysisSettingRepository);
+            }
+
+            @Test
+            @DisplayName("분석시작 이벤트가 정확히 1건 발행되어야 한다.")
+            void analysisStart_success_tc_02() {
+                // when
+                analysisService.analysisStart(givenRequest);
+
+                // then
+                final List<AnalysisStartEvent> events = applicationEvents.stream(AnalysisStartEvent.class).toList();
+                assertThat(events).hasSize(1);
+            }
+
+            @Test
+            @DisplayName("발행된 이벤트의 내부 데이터가 요청한 분석정보와 동일해야한다.")
+            void analysisStart_success_tc_03() {
+                // when
+                analysisService.analysisStart(givenRequest);
+
+                // then
+                final AnalysisStartEvent event = applicationEvents.stream(AnalysisStartEvent.class).toList().get(0);
+
+                assertThat(event.groupId()).isEqualTo(givenGroup.getGroupId());
+                assertThat(event.analysisId()).isEqualTo(givenAnalysis.getAnalysisId());
+
+                final List<AIAnalysisDTO.Request.MemberSetting> expectedMembers =
+                        givenMemberAnalysisSettings.stream()
+                                .map(ms -> AIAnalysisDTO.Request.MemberSetting.builder()
+                                        .memberId(ms.getMemberId())
+                                        .xPosition(ms.getXPosition())
+                                        .yPosition(ms.getYPosition())
+                                        .roadnameAddress(ms.getRoadnameAddress())
+                                        .inputText(ms.getInputText())
+                                        .categoryList(
+                                                ms.getCategorySettings().stream()
+                                                        .map(cs -> AIAnalysisDTO.Request.MemberSetting.CategorySetting.builder()
+                                                                .categoryId(cs.getCategoryId())
+                                                                .categoryName(cs.getCategoryName())
+                                                                .categoryTagId(cs.getCategoryTagId())
+                                                                .categoryTagName(cs.getCategoryTagName())
+                                                                .isPreferred(cs.getIsPreferred())
+                                                                .build())
+                                                        .toList()
+                                        )
+                                        .build())
+                                .toList();
+
+                assertThat(event.memberSettingList())
+                        .usingRecursiveComparison()
+                        .ignoringCollectionOrder()
+                        .isEqualTo(expectedMembers);
+            }
+
+            @Test
+            @DisplayName("분석시작 후 그룹의 분석상태가 진행중으로 변경되어야 한다.")
+            void analysisStart_success_tc_04() {
+                // when
+                analysisService.analysisStart(givenRequest);
+
+                // then
+                assertThat(givenAnalysis.getAnalysisStatus()).isEqualTo(AnalysisStatus.IN_PROGRESS);
+            }
+
+            @Test
+            @DisplayName("분석시작 후 반환된 응답이 요청한 그룹의 분석 정보와 일치해야 한다.")
+            void analysisStart_success_tc_05() {
+                // when
+                final AnalysisStartDTO.Response response = analysisService.analysisStart(givenRequest);
+
+                // then
+                assertThat(response.getGroupId()).isEqualTo(givenGroup.getGroupId());
+                assertThat(response.getAnalysisStatus()).isEqualTo(givenAnalysis.getAnalysisStatus().toString());
+                assertThat(response.getAnalysisId()).isEqualTo(givenAnalysis.getAnalysisId());
+            }
+        }
+
+
+        @Nested
+        @DisplayName("EXCEPTION")
+        class ExceptionTest {
+            @Test
+            @DisplayName("이미 분석이 시작된 그룹인 경우 `AnalysisAlreadyStartedForGroupIdException` 예외가 발생해야 한다.")
+            void analysisStart_exception_tc_01() {
+                // given
+                final String givenGroupId = UUID.randomUUID().toString().replace("-", "");
+                final Group mockGroup = mock(Group.class);
+
+                when(groupRepository.findById(givenGroupId)).thenReturn(Optional.of(mockGroup));
+                when(mockGroup.getGroupId()).thenReturn(givenGroupId);
+
+                // when
+                doThrow(AnalysisAlreadyStartedForGroupIdException.class).
+                        when(analysisStartPolicy).validate(givenGroupId);
+
+                // then
+                assertThrows(AnalysisAlreadyStartedForGroupIdException.class,
+                        () -> analysisService.analysisStart(AnalysisStartDTO.Request.builder()
+                                .groupId(givenGroupId)
+                                .build())
+                );
+            }
+
+            @Test
+            @DisplayName("분석제출 조건을 만족하지 못한 그룹인 경우 `AnalysisConditionNotSatisfiedForGroupIdException` 예외가 발생해야 한다.")
+            void analysisStart_exception_tc_02() {
+                // given
+                final String givenGroupId = UUID.randomUUID().toString().replace("-", "");
+                final Group mockGroup = mock(Group.class);
+
+                when(groupRepository.findById(givenGroupId)).thenReturn(Optional.of(mockGroup));
+                when(mockGroup.getGroupId()).thenReturn(givenGroupId);
+
+                // when
+                doThrow(AnalysisConditionNotSatisfiedForGroupIdException.class).
+                        when(analysisStartPolicy).validate(givenGroupId);
+
+                // then
+                assertThrows(AnalysisConditionNotSatisfiedForGroupIdException.class,
+                        () -> analysisService.analysisStart(AnalysisStartDTO.Request.builder()
+                                .groupId(givenGroupId)
+                                .build())
+                );
+            }
+
+            @Test
+            @DisplayName("존재하지 않는 그룹 식별자인 경우 `GroupNotFoundException` 예외가 발생해야 한다.")
+            void analysisStart_exception_tc_03() {
+                // given
+                final String givenGroupId = UUID.randomUUID().toString().replace("-", "");
+                final AnalysisStartDTO.Request request = mock(AnalysisStartDTO.Request.class);
+
+                when(request.getGroupId()).thenReturn(givenGroupId);
+                when(groupRepository.findById(givenGroupId)).thenReturn(Optional.empty());
+
+                // when & then
+                assertThrows(GroupNotFoundException.class,
+                        () -> analysisService.analysisStart(request)
+                );
+            }
+
+            @Test
+            @DisplayName("그룹에 대한 분석정보가 사전에 생성되어 있지 않은 경우 `AnalysisNotFoundForGroupIdException` 예외가 발생하여야 한다.")
+            void analysisStart_exception_tc_04() {
+                // given
+                when(groupRepository.findById(givenGroupId)).thenReturn(Optional.of(givenGroup));
+                doNothing().when(analysisStartPolicy).validate(givenGroup.getGroupId());
+                when(analysisRepository.findByGroupGroupId(givenGroup.getGroupId()))
+                        .thenReturn(Optional.empty());
+
+                // when & then
+                assertThrows(AnalysisNotFoundForGroupIdException.class,
+                        () -> analysisService.analysisStart(givenRequest)
+                );
+            }
+        }
+
+        private static MemberAnalysisSettingDTO buildMemberAnalysisSettingDto(
+                long memberId, double x, double y,
+                String roadnameAddress, String inputText,
+                List<MemberAnalysisSettingDTO.CategorySetting> categories
+        ) {
+            return MemberAnalysisSettingDTO.builder()
+                    .memberId(memberId)
+                    .xPosition(x)
+                    .yPosition(y)
+                    .roadnameAddress(roadnameAddress)
+                    .inputText(inputText)
+                    .categorySettings(categories)
+                    .build();
+        }
+
+        private static MemberAnalysisSettingDTO.CategorySetting buildCategorySettingDto(
+                long categoryId, String categoryName,
+                long categoryTagId, String categoryTagName, boolean isPreferred
+        ) {
+            return MemberAnalysisSettingDTO.CategorySetting.builder()
+                    .categoryId(categoryId)
+                    .categoryName(categoryName)
+                    .categoryTagId(categoryTagId)
+                    .categoryTagName(categoryTagName)
+                    .isPreferred(isPreferred)
+                    .build();
         }
     }
 }

--- a/src/test/java/com/waguwagu/weat/domain/analysis/service/AnalysisServiceTest.java
+++ b/src/test/java/com/waguwagu/weat/domain/analysis/service/AnalysisServiceTest.java
@@ -1,0 +1,175 @@
+package com.waguwagu.weat.domain.analysis.service;
+
+import com.waguwagu.weat.domain.analysis.adaptor.AIServiceAdaptor;
+import com.waguwagu.weat.domain.analysis.exception.AnalysisNotFoundForGroupIdException;
+import com.waguwagu.weat.domain.analysis.model.dto.GetAnalysisStatusDTO;
+import com.waguwagu.weat.domain.analysis.model.entity.Analysis;
+import com.waguwagu.weat.domain.analysis.model.entity.AnalysisStatus;
+import com.waguwagu.weat.domain.analysis.policy.AnalysisSettingSubmitPolicy;
+import com.waguwagu.weat.domain.analysis.policy.AnalysisStartPolicy;
+import com.waguwagu.weat.domain.analysis.repository.*;
+import com.waguwagu.weat.domain.category.repository.CategoryTagRepository;
+import com.waguwagu.weat.domain.group.exception.GroupNotFoundException;
+import com.waguwagu.weat.domain.group.model.entity.Group;
+import com.waguwagu.weat.domain.group.repository.GroupRepository;
+import com.waguwagu.weat.domain.group.repository.MemberRepository;
+import jakarta.validation.ConstraintViolationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.validation.beanvalidation.MethodValidationPostProcessor;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {
+        AnalysisService.class,
+        MethodValidationPostProcessor.class
+})
+class AnalysisServiceTest {
+
+    @MockBean
+    AIServiceAdaptor aiServiceAdaptor;
+    @MockBean
+    GroupRepository groupRepository;
+    @MockBean
+    MemberRepository memberRepository;
+    @MockBean
+    AnalysisRepository analysisRepository;
+    @MockBean
+    AnalysisSettingRepository analysisSettingRepository;
+    @MockBean
+    AnalysisSettingDetailRepository analysisSettingDetailRepository;
+    @MockBean
+    CategoryTagRepository categoryTagRepository;
+    @MockBean
+    AnalysisResultLikeRepository analysisResultLikeRepository;
+    @MockBean
+    AnalysisResultDetailRepository analysisResultDetailRepository;
+    @MockBean
+    ApplicationEventPublisher eventPublisher;
+    @MockBean
+    AnalysisStartPolicy analysisStartPolicy;
+    @MockBean
+    AnalysisSettingSubmitPolicy analysisSettingSubmitPolicy;
+
+    @Autowired
+    AnalysisService analysisService;
+
+    @Nested
+    @DisplayName("getAnalysisStatus - 분석진행상태 정보 조회")
+    class GetAnalysisStatus {
+
+        @Nested
+        @DisplayName("SUCCESS")
+        class SuccessTest {
+            /**
+             * @see com.waguwagu.weat.domain.analysis.model.dto.GetAnalysisStatusDTO.Response
+             */
+            @Test
+            @DisplayName("그룹에 대한 분석상태 정보가 실제 상태와 동일하게 반환되어야 한다.")
+            void getAnalysisStatus_success_tc_01() {
+                // given
+                final String givenGroupId = UUID.randomUUID().toString().replace("-", "");
+                final boolean givenIsSingleMemberGroup = false;
+                final boolean givenIsAnalysisStartPolicySatisfied = true;
+                final AnalysisStatus givenAnalysisStatus = AnalysisStatus.NOT_STARTED;
+                final Long givenSubmittedCount = 2L;
+
+                final Group mockGroup = mock(Group.class);
+                when(mockGroup.getGroupId()).thenReturn(givenGroupId);
+                when(mockGroup.isSingleMemberGroup()).thenReturn(givenIsSingleMemberGroup);
+
+                final Analysis mockAnalysis = mock(Analysis.class);
+                when(mockAnalysis.getAnalysisStatus()).thenReturn(givenAnalysisStatus);
+
+                final AnalysisStartPolicy.Result mockAnalysisStartPolicyResult = mock(AnalysisStartPolicy.Result.class);
+                when(mockAnalysisStartPolicyResult.isSatisfied()).thenReturn(givenIsAnalysisStartPolicySatisfied);
+
+                when(groupRepository.findById(givenGroupId)).thenReturn(Optional.of(mockGroup));
+                when(analysisRepository.findByGroupGroupId(givenGroupId)).thenReturn(Optional.of(mockAnalysis));
+                when(analysisSettingRepository.countAnalysisSettingByGroupId(givenGroupId)).thenReturn(givenSubmittedCount);
+                when(analysisStartPolicy.evaluate(givenGroupId)).thenReturn(mockAnalysisStartPolicyResult);
+
+                // when
+                final GetAnalysisStatusDTO.Response response = analysisService.getAnalysisStatus(givenGroupId);
+
+                // then
+                assertThat(response)
+                        .extracting(
+                                GetAnalysisStatusDTO.Response::getGroupId,
+                                GetAnalysisStatusDTO.Response::getIsSingleMemberGroup,
+                                GetAnalysisStatusDTO.Response::getSubmittedCount,
+                                GetAnalysisStatusDTO.Response::getIsAnalysisStartConditionSatisfied,
+                                GetAnalysisStatusDTO.Response::getAnalysisStatus
+                        )
+                        .containsExactly(
+                                givenGroupId,
+                                givenIsSingleMemberGroup,
+                                givenSubmittedCount,
+                                givenIsAnalysisStartPolicySatisfied,
+                                givenAnalysisStatus
+                        );
+            }
+        }
+
+        @Nested
+        @DisplayName("EXCEPTION")
+        class ExceptionTest {
+
+            @Test
+            @DisplayName("그룹 식별자가 null 인 경우 `ConstraintViolationException` 예외가 발생해야 한다.")
+            void getAnalysisStatus_exception_tc_01() {
+                // given
+                final String givenGroupId = null;
+
+                // when & then
+                assertThrows(
+                        ConstraintViolationException.class,
+                        () -> analysisService.getAnalysisStatus(givenGroupId)
+                );
+            }
+
+            @Test
+            @DisplayName("존재하지 않는 그룹 식별자인 경우 `GroupNotFoundException` 예외가 발생해야 한다.")
+            void getAnalysisStatus_exception_tc_02() {
+                // given
+                final String givenGroupId = UUID.randomUUID().toString().replace("-", "");
+                when(groupRepository.findById(givenGroupId)).thenReturn(Optional.empty());
+
+                // when & then
+                assertThrows(GroupNotFoundException.class, () ->
+                        analysisService.getAnalysisStatus(givenGroupId)
+                );
+            }
+
+            @Test
+            @DisplayName("그룹에 대한 분석 정보가 존재하지 않는 경우 `AnalysisNotFoundForGroupIdException` 예외가 발생해야 한다.")
+            void getAnalysisStatus_exception_tc_03() {
+                // given
+                final String givenGroupId = UUID.randomUUID().toString().replace("-", "");
+                final Group mockGroup = mock(Group.class);
+                when(groupRepository.findById(givenGroupId)).thenReturn(Optional.of(mockGroup));
+                when(analysisRepository.findByGroupGroupId(givenGroupId)).thenReturn(Optional.empty());
+
+                // when & then
+                assertThrows(AnalysisNotFoundForGroupIdException.class, () ->
+                        analysisService.getAnalysisStatus(givenGroupId)
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 🔥그룹별 분석 설정 제출 수 조회 성능 개선 및 self-invocation 이슈 해결

### 📌 개요
- 그룹 내 멤버 설정 제출 수 조회 시, 멤버리스트를 순회하며 N번 호출하던 부분을 제거하고 단일 쿼리로 조회할 수 있도록 변경하여 조회 성능 개선하였습니다.
- 분석 서비스 내 특정 조건 판별 로직에서 동일 클래스의 메서드를 직접 호출하던 문제를 수정하였습니다.  
  기존에는 self-invocation으로 인해 내부 호출된 메서드에 `@Transactional` AOP가 적용되지 않았으나,  
  정책 클래스를 사용하도록 변경하여 트랜잭션이 정상적으로 적용되도록 개선했습니다.

### ✅ 주요 변경 사항
- [x] 그룹별 분석 설정 제출 수 조회시 단일쿼리로 조회하도록 성능 개선
- [x] 분석시작가능 조건을 판별하는 정책 클래스 추가
- [x] 분석설정제출 조건을 판별하는 정책 클래스 추가
- [x] `AnalysisService` 에서 특정 조건 판별하는 로직을 정책 클래스로 위임
- [x] `AnalysisService` 내의 self-invocation 으로 인하여 `@Transactional` AOP 미적용되는 이슈 해결
- [x] 신규 QueryDSL 메서드 및 정책클래스에 대한 단위테스트 작성

### 📂 관련 이슈
- Relates: 
  - #89 
  - #96
  - #95 
- Closes:
  - #96 
  - #95 
### 📝 비고
- 없음