### PR TITLE
refactor/categorySetting - 카테고리 태그 조회 성능 개선

### DIFF
--- a/src/main/java/com/waguwagu/weat/domain/analysis/service/AnalysisService.java
+++ b/src/main/java/com/waguwagu/weat/domain/analysis/service/AnalysisService.java
@@ -37,14 +37,9 @@ public class AnalysisService {
     private final AIServiceAdaptor aiServiceAdaptor;
     private final GroupRepository groupRepository;
     private final MemberRepository memberRepository;
-    private final CategoryRepository categoryRepository;
     private final AnalysisRepository analysisRepository;
     private final AnalysisSettingRepository analysisSettingRepository;
     private final AnalysisSettingDetailRepository analysisSettingDetailRepository;
-    private final AnalysisAsyncExecutor analysisAsyncExecutor;
-    private final TextInputSettingRepository textInputSettingRepository;
-    private final LocationSettingRepository locationSettingRepository;
-    private final CategorySettingRepository categorySettingRepository;
     private final CategoryTagRepository categoryTagRepository;
     private final AnalysisResultLikeRepository analysisResultLikeRepository;
     private final AnalysisResultDetailRepository analysisResultDetailRepository;
@@ -123,7 +118,7 @@ public class AnalysisService {
                 .member(member)
                 .build();
 
-        analysisSettingRepository.save(analysisSetting);
+        AnalysisSetting savedAnalysisSetting = analysisSettingRepository.save(analysisSetting);
 
         // 위치 설정
         LocationSetting locationSetting = LocationSetting.builder()
@@ -175,7 +170,7 @@ public class AnalysisService {
 
         return SubmitAnalysisSettingDTO.Response.builder()
                 .memberId(member.getMemberId())
-                .analysisSettingId(analysisSetting.getAnalysisSettingId())
+                .analysisSettingId(savedAnalysisSetting.getAnalysisSettingId())
                 .build();
     }
 

--- a/src/main/java/com/waguwagu/weat/domain/analysis/service/AnalysisService.java
+++ b/src/main/java/com/waguwagu/weat/domain/analysis/service/AnalysisService.java
@@ -102,6 +102,7 @@ public class AnalysisService {
     }
 
     // 멤버별 분석 설정 제출
+    @Transactional
     public SubmitAnalysisSettingDTO.Response submitAnalysisSetting(SubmitAnalysisSettingDTO.Request requestDto) {
         // 회원 정보 조회
         Member member = memberRepository.findById(requestDto.getMemberId())

--- a/src/main/java/com/waguwagu/weat/domain/analysis/service/AnalysisService.java
+++ b/src/main/java/com/waguwagu/weat/domain/analysis/service/AnalysisService.java
@@ -4,7 +4,6 @@ import com.waguwagu.weat.domain.analysis.adaptor.AIServiceAdaptor;
 import com.waguwagu.weat.domain.analysis.event.AnalysisStartEvent;
 import com.waguwagu.weat.domain.analysis.exception.AnalysisNotFoundForGroupIdException;
 import com.waguwagu.weat.domain.analysis.exception.AnalysisResultDetailNotFoundException;
-import com.waguwagu.weat.domain.analysis.exception.MemberAlreadySubmitSettingForMemberIdException;
 import com.waguwagu.weat.domain.analysis.exception.MemberNotFoundException;
 import com.waguwagu.weat.domain.analysis.model.dto.*;
 import com.waguwagu.weat.domain.analysis.model.entity.*;
@@ -13,7 +12,6 @@ import com.waguwagu.weat.domain.analysis.policy.AnalysisStartPolicy;
 import com.waguwagu.weat.domain.analysis.repository.*;
 import com.waguwagu.weat.domain.category.exception.CategoryTagNotFoundException;
 import com.waguwagu.weat.domain.category.model.entity.CategoryTag;
-import com.waguwagu.weat.domain.category.repository.CategoryRepository;
 import com.waguwagu.weat.domain.category.repository.CategoryTagRepository;
 import com.waguwagu.weat.domain.group.exception.GroupNotFoundException;
 import com.waguwagu.weat.domain.group.model.entity.Group;
@@ -122,7 +120,7 @@ public class AnalysisService {
                 .build();
 
         // 설정 정보 저장
-        analysisSettingRepository.save(analysisSetting);
+        AnalysisSetting savedAnalysisSetting = analysisSettingRepository.save(analysisSetting);
 
         // 위치 설정
         LocationSetting locationSetting = LocationSetting.builder()
@@ -141,7 +139,7 @@ public class AnalysisService {
                 .distinct()
                 .toList();
 
-        Map<Long, CategoryTag> categoryTagMap = categoryTagRepository.findByIdIn(categoryTagIds).stream()
+        Map<Long, CategoryTag> categoryTagMap = categoryTagRepository.findByCategoryTagIdIn(categoryTagIds).stream()
                 .collect(Collectors.toMap(CategoryTag::getCategoryTagId, Function.identity()));
 
         List<CategorySetting> categorySettings = categorySettingList.stream()

--- a/src/main/java/com/waguwagu/weat/domain/analysis/service/AnalysisService.java
+++ b/src/main/java/com/waguwagu/weat/domain/analysis/service/AnalysisService.java
@@ -24,8 +24,9 @@ import org.springframework.transaction.annotation.Transactional;
 import reactor.core.publisher.Mono;
 
 import java.time.Duration;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -134,20 +135,34 @@ public class AnalysisService {
         analysisSettingDetailRepository.save(locationSetting);
 
         // 카테고리 설정
-        for (SubmitAnalysisSettingDTO.Request.CategorySetting categorySettingDTO : requestDto.getCategorySettingList()) {
+        List<SubmitAnalysisSettingDTO.Request.CategorySetting> categorySettingList = requestDto.getCategorySettingList();
+        List<Long> categoryTagIds = categorySettingList.stream()
+                .map(SubmitAnalysisSettingDTO.Request.CategorySetting::getCategoryTagId)
+                .distinct()
+                .toList();
 
-            CategoryTag categoryTag = categoryTagRepository.findById(categorySettingDTO.getCategoryTagId())
-                    .orElseThrow(() -> new CategoryTagNotFoundException(categorySettingDTO.getCategoryTagId()));
+        Map<Long, CategoryTag> categoryTagMap = categoryTagRepository.findByIdIn(categoryTagIds).stream()
+                .collect(Collectors.toMap(CategoryTag::getCategoryTagId, Function.identity()));
 
-            CategorySetting categorySetting = CategorySetting.builder()
-                    .analysisSetting(analysisSetting)
-                    .category(categoryTag.getCategory())
-                    .categoryTag(categoryTag)
-                    .isPreferred(categorySettingDTO.getIsPreferred())
-                    .build();
+        List<CategorySetting> categorySettings = categorySettingList.stream()
+                .map(dto -> {
+                    Long categoryTagId = dto.getCategoryTagId();
+                    CategoryTag categoryTag = categoryTagMap.get(categoryTagId);
 
-            analysisSettingDetailRepository.save(categorySetting);
-        }
+                    if (categoryTag == null) {
+                        throw new CategoryTagNotFoundException(categoryTagId);
+                    }
+
+                    return CategorySetting.builder()
+                            .analysisSetting(analysisSetting)
+                            .category(categoryTag.getCategory())
+                            .categoryTag(categoryTag)
+                            .isPreferred(dto.getIsPreferred())
+                            .build();
+                })
+                .collect(Collectors.toList());
+
+        analysisSettingDetailRepository.saveAll(categorySettings);
 
         // 텍스트 입력 설정
         TextInputSetting textInputSetting = TextInputSetting.builder()

--- a/src/main/java/com/waguwagu/weat/domain/category/repository/CategoryTagRepository.java
+++ b/src/main/java/com/waguwagu/weat/domain/category/repository/CategoryTagRepository.java
@@ -10,5 +10,5 @@ public interface CategoryTagRepository extends JpaRepository<CategoryTag, Long> 
     List<CategoryTag> findAllByCategoryCategoryIdOrderByCategoryTagOrder(Long categoryId);
     List<CategoryTag> findByCategoryOrderByCategoryTagOrderDesc(Category category);
 
-    List<CategoryTag> findByIdIn(List<Long> categoryTagIds);
+    List<CategoryTag> findByCategoryTagIdIn(List<Long> categoryTagIds);
 }

--- a/src/main/java/com/waguwagu/weat/domain/category/repository/CategoryTagRepository.java
+++ b/src/main/java/com/waguwagu/weat/domain/category/repository/CategoryTagRepository.java
@@ -9,4 +9,6 @@ import java.util.List;
 public interface CategoryTagRepository extends JpaRepository<CategoryTag, Long> {
     List<CategoryTag> findAllByCategoryCategoryIdOrderByCategoryTagOrder(Long categoryId);
     List<CategoryTag> findByCategoryOrderByCategoryTagOrderDesc(Category category);
+
+    List<CategoryTag> findByIdIn(List<Long> categoryTagIds);
 }

--- a/src/test/java/com/waguwagu/weat/domain/analysis/service/AnalysisServiceTest.java
+++ b/src/test/java/com/waguwagu/weat/domain/analysis/service/AnalysisServiceTest.java
@@ -1,0 +1,283 @@
+package com.waguwagu.weat.domain.analysis.service;
+
+
+import com.waguwagu.weat.domain.analysis.adaptor.AIServiceAdaptor;
+import com.waguwagu.weat.domain.analysis.model.dto.SubmitAnalysisSettingDTO;
+import com.waguwagu.weat.domain.analysis.model.entity.*;
+import com.waguwagu.weat.domain.analysis.repository.*;
+import com.waguwagu.weat.domain.category.model.entity.Category;
+import com.waguwagu.weat.domain.category.model.entity.CategoryTag;
+import com.waguwagu.weat.domain.category.repository.CategoryRepository;
+import com.waguwagu.weat.domain.category.repository.CategoryTagRepository;
+import com.waguwagu.weat.domain.group.model.entity.Group;
+import com.waguwagu.weat.domain.group.model.entity.Member;
+import com.waguwagu.weat.domain.group.repository.GroupRepository;
+import com.waguwagu.weat.domain.group.repository.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.event.RecordApplicationEvents;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.validation.beanvalidation.MethodValidationPostProcessor;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.BDDMockito.*;
+
+@RecordApplicationEvents
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {
+        AnalysisService.class,
+        MethodValidationPostProcessor.class
+})
+public class AnalysisServiceTest {
+
+    @MockBean
+    AIServiceAdaptor aiServiceAdaptor;
+    @MockBean
+    GroupRepository groupRepository;
+    @MockBean
+    MemberRepository memberRepository;
+    @MockBean
+    AnalysisRepository analysisRepository;
+    @MockBean
+    AnalysisSettingRepository analysisSettingRepository;
+    @MockBean
+    AnalysisSettingDetailRepository analysisSettingDetailRepository;
+    @MockBean
+    CategoryRepository categoryRepository;
+    @MockBean
+    CategoryTagRepository categoryTagRepository;
+    @MockBean
+    AnalysisResultLikeRepository analysisResultLikeRepository;
+    @MockBean
+    AnalysisResultDetailRepository analysisResultDetailRepository;
+    @MockBean
+    AnalysisAsyncExecutor analysisAsyncExecutor;
+
+    @Autowired
+    AnalysisService analysisService;
+
+
+    @Nested
+    @DisplayName("submitAnalysisSetting - 멤버별 분석 설정 제출")
+    class SubmitAnalysisSetting {
+
+        private SubmitAnalysisSettingDTO.Request mockRequest;
+
+        private GivenContext givenSubmitSuccess() {
+            // --- given 값들 ---
+            final Long givenMemberId = 1L;
+            final String givenGroupId = "group-10";
+            final Long givenAnalysisSettingId = 999L;
+
+            final Double givenXPosition = 37.5666102;
+            final Double givenYPosition = 126.9783881;
+            final String givenRoadnameAddress = "서울특별시 중구 세종대로 110";
+
+            final Long givenCategoryTagId1 = 75L;
+            final Long givenCategoryTagId2 = 83L;
+            final boolean givenIsPreferred1 = true;
+            final boolean givenIsPreferred2 = false;
+
+            final Long givenCategoryId1 = 10L;
+            final Long givenCategoryId2 = 11L;
+            final String givenCategoryName1 = "한식";
+            final String givenCategoryName2 = "일식";
+            final String givenInputText = "조용하고 덜 혼잡한 곳을 원해요";
+
+            // --- Request DTO mock ---
+            mockRequest = mock(SubmitAnalysisSettingDTO.Request.class);
+            when(mockRequest.getMemberId()).thenReturn(givenMemberId);
+
+            // 위치 설정
+            final SubmitAnalysisSettingDTO.Request.LocationSetting mockLocationSetting =
+                    mock(SubmitAnalysisSettingDTO.Request.LocationSetting.class);
+            when(mockLocationSetting.getXPosition()).thenReturn(givenXPosition);
+            when(mockLocationSetting.getYPosition()).thenReturn(givenYPosition);
+            when(mockLocationSetting.getRoadnameAddress()).thenReturn(givenRoadnameAddress);
+            when(mockRequest.getLocationSetting()).thenReturn(mockLocationSetting);
+
+            // 카테고리 설정
+            final SubmitAnalysisSettingDTO.Request.CategorySetting mockCategorySetting1 =
+                    mock(SubmitAnalysisSettingDTO.Request.CategorySetting.class);
+            when(mockCategorySetting1.getCategoryTagId()).thenReturn(givenCategoryTagId1);
+            when(mockCategorySetting1.getIsPreferred()).thenReturn(givenIsPreferred1);
+
+            final SubmitAnalysisSettingDTO.Request.CategorySetting mockCategorySetting2 =
+                    mock(SubmitAnalysisSettingDTO.Request.CategorySetting.class);
+            when(mockCategorySetting2.getCategoryTagId()).thenReturn(givenCategoryTagId2);
+            when(mockCategorySetting2.getIsPreferred()).thenReturn(givenIsPreferred2);
+            when(mockRequest.getCategorySettingList())
+                    .thenReturn(List.of(mockCategorySetting1, mockCategorySetting2));
+
+            // 텍스트 입력 설정
+            final SubmitAnalysisSettingDTO.Request.TextInputSetting mockTextInputSetting =
+                    mock(SubmitAnalysisSettingDTO.Request.TextInputSetting.class);
+            when(mockTextInputSetting.getInputText()).thenReturn(givenInputText);
+            when(mockRequest.getTextInputSetting()).thenReturn(mockTextInputSetting);
+
+            // --- Group / Member / Analysis mock ---
+            final Group mockGroup = mock(Group.class);
+            when(mockGroup.getGroupId()).thenReturn(givenGroupId);
+
+            final Member mockMember = mock(Member.class);
+            when(mockMember.getMemberId()).thenReturn(givenMemberId);
+            when(mockMember.getGroup()).thenReturn(mockGroup);
+
+            final Analysis mockAnalysis = mock(Analysis.class);
+
+            // --- Repository stubbing ---
+            when(memberRepository.findById(givenMemberId))
+                    .thenReturn(Optional.of(mockMember));
+
+            // isMemberSubmitAnalysisSetting 내부에서 사용하는 중복 제출 여부
+            when(analysisSettingRepository.existsByMemberMemberId(givenMemberId))
+                    .thenReturn(false);
+
+            when(analysisRepository.findByGroupGroupId(givenGroupId))
+                    .thenReturn(Optional.of(mockAnalysis));
+
+            final AnalysisSetting mockSavedAnalysisSetting = mock(AnalysisSetting.class);
+            when(mockSavedAnalysisSetting.getAnalysisSettingId())
+                    .thenReturn(givenAnalysisSettingId);
+
+            when(analysisSettingRepository.save(any(AnalysisSetting.class)))
+                    .thenReturn(mockSavedAnalysisSetting);
+
+            // --- Category 엔티티 + CategoryTag mock ---
+            final Category mockCategory1 = mock(Category.class);
+            when(mockCategory1.getCategoryId()).thenReturn(givenCategoryId1);
+            when(mockCategory1.getCategoryName()).thenReturn(givenCategoryName1);
+
+            final Category mockCategory2 = mock(Category.class);
+            when(mockCategory2.getCategoryId()).thenReturn(givenCategoryId2);
+            when(mockCategory2.getCategoryName()).thenReturn(givenCategoryName2);
+
+            final CategoryTag mockCategoryTag1 = mock(CategoryTag.class);
+            when(mockCategoryTag1.getCategoryTagId()).thenReturn(givenCategoryTagId1);
+            when(mockCategoryTag1.getCategory()).thenReturn(mockCategory1);
+
+            final CategoryTag mockCategoryTag2 = mock(CategoryTag.class);
+            when(mockCategoryTag2.getCategoryTagId()).thenReturn(givenCategoryTagId2);
+            when(mockCategoryTag2.getCategory()).thenReturn(mockCategory2);
+
+            when(categoryTagRepository.findByIdIn(List.of(givenCategoryTagId1, givenCategoryTagId2)))
+                    .thenReturn(List.of(mockCategoryTag1, mockCategoryTag2));
+
+            // 중복 제출 false
+            when(analysisSettingRepository.existsByMemberMemberId(givenMemberId)).thenReturn(false);
+
+            return new GivenContext(
+                    givenMemberId,
+                    givenAnalysisSettingId,
+                    givenXPosition,
+                    givenYPosition,
+                    givenRoadnameAddress,
+                    givenCategoryTagId1,
+                    givenCategoryTagId2,
+                    givenIsPreferred1,
+                    givenIsPreferred2,
+                    givenInputText
+            );
+        }
+
+        private record GivenContext(
+                Long memberId,
+                Long analysisSettingId,
+                Double x,
+                Double y,
+                String addr,
+                Long tagId1,
+                Long tagId2,
+                Boolean pref1,
+                Boolean pref2,
+                String inputText
+        ){ }
+
+
+        @Nested
+        @DisplayName("SUCCESS")
+        class SuccessTest {
+
+            @Test
+            @DisplayName("정상 제출 시 응답이 올바르게 반환되어야 한다.")
+            void submitAnalysisSetting_success_response_tc_01() {
+                // given
+                final GivenContext ctx = givenSubmitSuccess();
+
+                // when
+                final SubmitAnalysisSettingDTO.Response response =
+                        analysisService.submitAnalysisSetting(mockRequest);
+
+                // then
+                assertThat(response)
+                        .extracting(
+                                SubmitAnalysisSettingDTO.Response::getMemberId,
+                                SubmitAnalysisSettingDTO.Response::getAnalysisSettingId
+                        )
+                        .containsExactly(
+                                ctx.memberId,
+                                ctx.analysisSettingId
+                        );
+            }
+
+
+            @Test
+            @DisplayName("정상 제출 시 위치/카테고리/텍스트가 저장 요청 값과 동일해야 한다.")
+            void submitAnalysisSetting_success_persisted_values_tc_02() {
+                // given
+                final GivenContext ctx = givenSubmitSuccess();
+
+                // when
+                analysisService.submitAnalysisSetting(mockRequest);
+
+                // then (captor 검증)
+                // Location
+                ArgumentCaptor<LocationSetting> locationCaptor = ArgumentCaptor.forClass(LocationSetting.class);
+                then(analysisSettingDetailRepository).should(times(1)).save(locationCaptor.capture());
+                LocationSetting savedLoc = locationCaptor.getValue();
+
+                assertThat(savedLoc)
+                        .extracting(
+                                LocationSetting::getXPosition,
+                                LocationSetting::getYPosition,
+                                LocationSetting::getRoadnameAddress
+                        )
+                        .containsExactly(ctx.x, ctx.y, ctx.addr);
+
+                // Category
+                ArgumentCaptor<List> categoryCaptor = ArgumentCaptor.forClass(List.class);
+                then(analysisSettingDetailRepository).should(times(1)).saveAll(categoryCaptor.capture());
+
+                @SuppressWarnings("unchecked")
+                List<CategorySetting> savedCats = (List<CategorySetting>) categoryCaptor.getValue();
+
+                assertThat(savedCats).hasSize(2);
+                assertThat(savedCats)
+                        .extracting(cs -> cs.getCategoryTag().getCategoryTagId(),
+                                CategorySetting::getIsPreferred)
+                        .containsExactlyInAnyOrder(
+                                tuple(ctx.tagId1, ctx.pref1),
+                                tuple(ctx.tagId2, ctx.pref2)
+                        );
+
+                // Text
+                ArgumentCaptor<TextInputSetting> textCaptor = ArgumentCaptor.forClass(TextInputSetting.class);
+                then(analysisSettingDetailRepository).should(times(1)).save(textCaptor.capture());
+                assertThat(textCaptor.getValue().getInputText()).isEqualTo(ctx.inputText);
+            }
+
+
+        }
+
+    }
+}

--- a/src/test/java/com/waguwagu/weat/domain/analysis/service/AnalysisServiceTest.java
+++ b/src/test/java/com/waguwagu/weat/domain/analysis/service/AnalysisServiceTest.java
@@ -5,18 +5,19 @@ import com.waguwagu.weat.domain.analysis.event.AnalysisStartEvent;
 import com.waguwagu.weat.domain.analysis.exception.AnalysisAlreadyStartedForGroupIdException;
 import com.waguwagu.weat.domain.analysis.exception.AnalysisConditionNotSatisfiedForGroupIdException;
 import com.waguwagu.weat.domain.analysis.exception.AnalysisNotFoundForGroupIdException;
-import com.waguwagu.weat.domain.analysis.model.dto.AIAnalysisDTO;
-import com.waguwagu.weat.domain.analysis.model.dto.AnalysisStartDTO;
-import com.waguwagu.weat.domain.analysis.model.dto.GetAnalysisStatusDTO;
-import com.waguwagu.weat.domain.analysis.model.dto.MemberAnalysisSettingDTO;
-import com.waguwagu.weat.domain.analysis.model.entity.Analysis;
-import com.waguwagu.weat.domain.analysis.model.entity.AnalysisStatus;
+import com.waguwagu.weat.domain.analysis.exception.MemberNotFoundException;
+import com.waguwagu.weat.domain.analysis.model.dto.*;
+import com.waguwagu.weat.domain.analysis.model.entity.*;
 import com.waguwagu.weat.domain.analysis.policy.AnalysisSettingSubmitPolicy;
 import com.waguwagu.weat.domain.analysis.policy.AnalysisStartPolicy;
 import com.waguwagu.weat.domain.analysis.repository.*;
+import com.waguwagu.weat.domain.category.exception.CategoryTagNotFoundException;
+import com.waguwagu.weat.domain.category.model.entity.Category;
+import com.waguwagu.weat.domain.category.model.entity.CategoryTag;
 import com.waguwagu.weat.domain.category.repository.CategoryTagRepository;
 import com.waguwagu.weat.domain.group.exception.GroupNotFoundException;
 import com.waguwagu.weat.domain.group.model.entity.Group;
+import com.waguwagu.weat.domain.group.model.entity.Member;
 import com.waguwagu.weat.domain.group.repository.GroupRepository;
 import com.waguwagu.weat.domain.group.repository.MemberRepository;
 import jakarta.validation.ConstraintViolationException;
@@ -25,6 +26,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -39,7 +41,9 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.tuple;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.*;
 
 @RecordApplicationEvents
@@ -181,6 +185,279 @@ class AnalysisServiceTest {
             }
         }
     }
+
+
+    @Nested
+    @DisplayName("submitAnalysisSetting - 멤버별 분석 설정 제출")
+    class SubmitAnalysisSetting {
+
+        private SubmitAnalysisSettingDTO.Request mockRequest;
+
+        // 공통 fixture 값들
+        private Long givenMemberId;
+        private String givenGroupId;
+        private Long givenAnalysisSettingId;
+
+        private Double givenXPosition;
+        private Double givenYPosition;
+        private String givenRoadnameAddress;
+
+        private Long givenCategoryTagId1;
+        private Long givenCategoryTagId2;
+        private boolean givenIsPreferred1;
+        private boolean givenIsPreferred2;
+
+        private Long givenCategoryId1;
+        private Long givenCategoryId2;
+        private String givenCategoryName1;
+        private String givenCategoryName2;
+        private String givenInputText;
+
+        @BeforeEach
+        void setUpRequest() {
+            // 값 세팅
+            givenMemberId = 1L;
+            givenGroupId = UUID.randomUUID().toString().replace("-", "");
+            givenAnalysisSettingId = 999L;
+
+            givenXPosition = 37.5666102;
+            givenYPosition = 126.9783881;
+            givenRoadnameAddress = "서울특별시 중구 세종대로 110";
+
+            givenCategoryTagId1 = 75L;
+            givenCategoryTagId2 = 83L;
+            givenIsPreferred1 = true;
+            givenIsPreferred2 = false;
+
+            givenCategoryId1 = 10L;
+            givenCategoryId2 = 11L;
+            givenCategoryName1 = "한식";
+            givenCategoryName2 = "일식";
+            givenInputText = "조용하고 덜 혼잡한 곳을 원해요";
+
+            // Request DTO mocking
+            mockRequest = mock(SubmitAnalysisSettingDTO.Request.class);
+            when(mockRequest.getMemberId()).thenReturn(givenMemberId);
+
+            // 위치 설정
+            SubmitAnalysisSettingDTO.Request.LocationSetting mockLocationSetting =
+                    mock(SubmitAnalysisSettingDTO.Request.LocationSetting.class);
+            when(mockLocationSetting.getXPosition()).thenReturn(givenXPosition);
+            when(mockLocationSetting.getYPosition()).thenReturn(givenYPosition);
+            when(mockLocationSetting.getRoadnameAddress()).thenReturn(givenRoadnameAddress);
+            when(mockRequest.getLocationSetting()).thenReturn(mockLocationSetting);
+
+            // 카테고리 설정
+            SubmitAnalysisSettingDTO.Request.CategorySetting mockCategorySetting1 =
+                    mock(SubmitAnalysisSettingDTO.Request.CategorySetting.class);
+            when(mockCategorySetting1.getCategoryTagId()).thenReturn(givenCategoryTagId1);
+            when(mockCategorySetting1.getIsPreferred()).thenReturn(givenIsPreferred1);
+
+            SubmitAnalysisSettingDTO.Request.CategorySetting mockCategorySetting2 =
+                    mock(SubmitAnalysisSettingDTO.Request.CategorySetting.class);
+            when(mockCategorySetting2.getCategoryTagId()).thenReturn(givenCategoryTagId2);
+            when(mockCategorySetting2.getIsPreferred()).thenReturn(givenIsPreferred2);
+
+            when(mockRequest.getCategorySettingList())
+                    .thenReturn(List.of(mockCategorySetting1, mockCategorySetting2));
+
+            // 텍스트 입력 설정
+            SubmitAnalysisSettingDTO.Request.TextInputSetting mockTextInputSetting =
+                    mock(SubmitAnalysisSettingDTO.Request.TextInputSetting.class);
+            when(mockTextInputSetting.getInputText()).thenReturn(givenInputText);
+            when(mockRequest.getTextInputSetting()).thenReturn(mockTextInputSetting);
+
+
+            // Group / Member Mock
+            Group mockGroup = mock(Group.class);
+            when(mockGroup.getGroupId()).thenReturn(givenGroupId);
+
+            Member mockMember = mock(Member.class);
+            when(mockMember.getMemberId()).thenReturn(givenMemberId);
+            when(mockMember.getGroup()).thenReturn(mockGroup);
+
+            when(memberRepository.findById(givenMemberId))
+                    .thenReturn(Optional.of(mockMember));
+        }
+
+        private GivenContext givenSubmitSuccess() {
+            // Analysis mock
+            Analysis mockAnalysis = mock(Analysis.class);
+
+            // Repository stubbing
+            when(analysisSettingRepository.existsByMemberMemberId(givenMemberId)).thenReturn(false);
+
+            when(analysisRepository.findByGroupGroupId(givenGroupId)).thenReturn(Optional.of(mockAnalysis));
+
+            AnalysisSetting mockSavedAnalysisSetting = mock(AnalysisSetting.class);
+            when(mockSavedAnalysisSetting.getAnalysisSettingId()).thenReturn(givenAnalysisSettingId);
+
+            when(analysisSettingRepository.save(any(AnalysisSetting.class))).thenReturn(mockSavedAnalysisSetting);
+
+            // Category / CategoryTag mock
+            Category mockCategory1 = mock(Category.class);
+            when(mockCategory1.getCategoryId()).thenReturn(givenCategoryId1);
+            when(mockCategory1.getCategoryName()).thenReturn(givenCategoryName1);
+
+            Category mockCategory2 = mock(Category.class);
+            when(mockCategory2.getCategoryId()).thenReturn(givenCategoryId2);
+            when(mockCategory2.getCategoryName()).thenReturn(givenCategoryName2);
+
+            CategoryTag mockCategoryTag1 = mock(CategoryTag.class);
+            when(mockCategoryTag1.getCategoryTagId()).thenReturn(givenCategoryTagId1);
+            when(mockCategoryTag1.getCategory()).thenReturn(mockCategory1);
+
+            CategoryTag mockCategoryTag2 = mock(CategoryTag.class);
+            when(mockCategoryTag2.getCategoryTagId()).thenReturn(givenCategoryTagId2);
+            when(mockCategoryTag2.getCategory()).thenReturn(mockCategory2);
+
+            when(categoryTagRepository.findByCategoryTagIdIn(List.of(givenCategoryTagId1, givenCategoryTagId2)))
+                    .thenReturn(List.of(mockCategoryTag1, mockCategoryTag2));
+
+            return new GivenContext(
+                    givenMemberId,
+                    givenAnalysisSettingId,
+                    givenXPosition,
+                    givenYPosition,
+                    givenRoadnameAddress,
+                    givenCategoryTagId1,
+                    givenCategoryTagId2,
+                    givenIsPreferred1,
+                    givenIsPreferred2,
+                    givenInputText
+            );
+        }
+
+        private record GivenContext(
+                Long memberId, Long analysisSettingId,
+                Double x, Double y, String addr,
+                Long tagId1, Long tagId2, Boolean pref1, Boolean pref2,
+                String inputText
+        ) {
+        }
+
+
+        @Nested
+        @DisplayName("SUCCESS")
+        class SuccessTest {
+
+            @Test
+            @DisplayName("정상 제출 시 응답이 올바르게 반환되어야 한다.")
+            void submitAnalysisSetting_success_tc_01() {
+                // given
+                final GivenContext ctx = givenSubmitSuccess();
+
+                // when
+                final SubmitAnalysisSettingDTO.Response response =
+                        analysisService.submitAnalysisSetting(mockRequest);
+
+                // then
+                assertThat(response)
+                        .extracting(
+                                SubmitAnalysisSettingDTO.Response::getMemberId,
+                                SubmitAnalysisSettingDTO.Response::getAnalysisSettingId
+                        )
+                        .containsExactly(
+                                ctx.memberId,
+                                ctx.analysisSettingId
+                        );
+            }
+
+
+            @Test
+            @DisplayName("정상 제출 시 위치/카테고리/텍스트가 저장 요청 값과 동일해야 한다.")
+            void submitAnalysisSetting_success_tc_02() {
+                // given
+                final GivenContext ctx = givenSubmitSuccess();
+
+                // when
+                analysisService.submitAnalysisSetting(mockRequest);
+
+                // then
+                // Location
+                ArgumentCaptor<LocationSetting> locationCaptor = ArgumentCaptor.forClass(LocationSetting.class);
+                then(analysisSettingDetailRepository).should(times(1)).save(locationCaptor.capture());
+                LocationSetting savedLoc = locationCaptor.getValue();
+
+                assertThat(savedLoc)
+                        .extracting(
+                                LocationSetting::getXPosition,
+                                LocationSetting::getYPosition,
+                                LocationSetting::getRoadnameAddress
+                        )
+                        .containsExactly(ctx.x, ctx.y, ctx.addr);
+
+                // Category
+                @SuppressWarnings("unchecked")
+                ArgumentCaptor<List<CategorySetting>> categoryCaptor =
+                        (ArgumentCaptor<List<CategorySetting>>) (ArgumentCaptor<?>) ArgumentCaptor.forClass(List.class);
+                then(analysisSettingDetailRepository).should(times(1)).saveAll(categoryCaptor.capture());
+
+                List<CategorySetting> savedCats = categoryCaptor.getValue();
+
+                assertThat(savedCats).hasSize(2);
+                assertThat(savedCats)
+                        .extracting(cs -> cs.getCategoryTag().getCategoryTagId(),
+                                CategorySetting::getIsPreferred)
+                        .containsExactlyInAnyOrder(
+                                tuple(ctx.tagId1, ctx.pref1),
+                                tuple(ctx.tagId2, ctx.pref2)
+                        );
+
+                // Text
+                ArgumentCaptor<TextInputSetting> textCaptor = ArgumentCaptor.forClass(TextInputSetting.class);
+                then(analysisSettingDetailRepository).should(times(1)).save(textCaptor.capture());
+                assertThat(textCaptor.getValue().getInputText()).isEqualTo(ctx.inputText);
+            }
+
+        }
+
+
+        @Nested
+        @DisplayName("EXCEPTION")
+        class ExceptionTest {
+            @Test
+            @DisplayName("존재하지 않는 멤버 ID면 MemberNotFoundException이 발생해야 한다.")
+            void submitAnalysisSetting_exception_tc_01() {
+                // given
+                when(memberRepository.findById(givenMemberId)).thenReturn(Optional.empty());
+
+                // when & then
+                assertThrows(MemberNotFoundException.class, () ->
+                        analysisService.submitAnalysisSetting(mockRequest)
+                );
+            }
+
+
+            @Test
+            @DisplayName("그룹에 대한 분석정보가 없으면 AnalysisNotFoundForGroupIdException이 발생하여야 한다.")
+            void submitAnalysisSetting_exception_tc_02() {
+                // given
+                when(analysisRepository.findByGroupGroupId(givenGroupId)).thenReturn(Optional.empty());
+
+                // when & then
+                assertThrows(AnalysisNotFoundForGroupIdException.class,
+                        () -> analysisService.submitAnalysisSetting(mockRequest)
+                );
+            }
+
+            @Test
+            @DisplayName("요청에 포함된 카테고리 태그 중 하나라도 존재하지 않으면 CategoryTagNotFoundException이 발생하여야 한다.")
+            void submitAnalysisSetting_exception_tc_03() {
+                // given
+                givenSubmitSuccess();
+
+                // 카테고리 태그 조회 부분만 override
+                when(categoryTagRepository.findByCategoryTagIdIn(anyList())).thenReturn(List.of());
+
+                // when & then
+                assertThrows(CategoryTagNotFoundException.class,
+                        () -> analysisService.submitAnalysisSetting(mockRequest)
+                );
+            }
+        }
+    }
+
 
     @Nested
     @DisplayName("analysisStart - 분석시작")


### PR DESCRIPTION
## 🔥 카테고리 태그 조회 성능 개선

### 📌 개요
- 분석 설정 제출 시 카테고리 태그가 개별적으로 조회되던 문제를 개선했습니다.
- 요청에 포함된 모든 categoryTagId를 한 번에 조회하도록 리팩터링하여 조회 성능을 향상했습니다.

### ✅ 주요 변경 사항
- [x] 설정 제출 시 카테고리 태그를 단일 쿼리(findByCategoryTagIdIn) 로 조회하도록 변경
- [x] 조회된 태그들을 Map 형태로 매핑 후 CategorySetting 객체를 재구성하도록 수정
- [x] 분석 설정 제출(`submitAnalysisSetting`) 서비스 로직에 대한 단위 테스트 추가

### 📂 관련 이슈
- Relates: #98 
- Closes: #98 

### 📝 비고